### PR TITLE
Add missing parts to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ sudo: false
 
 rvm:
   - 2.1.0
+
+gemfile: chef/cookbooks/pacemaker/Gemfile
+install: cd chef/cookbooks/pacemaker && bundle install --without development
+script: exec rspec


### PR DESCRIPTION
While the crowbar merge we lost some parts of the `.travis.yml`. This
commit re adds the missing bits.