### PR TITLE
crowbar-pacemaker: Only set apache_params if RA is the OCF RA

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb
@@ -40,11 +40,11 @@ service_name = "apache2"
 agent_name = node[:pacemaker][service_name][:agent]
 
 apache_params = {}
-unless agent_name == "systemd:apache2"
+if agent_name == "ocf:heartbeat:apache"
   apache_params["statusurl"] = "http://127.0.0.1:#{listening_port}/server-status"
-end
-unless crowbar_defined_ports.values.select{ |service| service.has_key? :ssl }.empty?
-  apache_params["options"] = "-DSSL"
+  unless crowbar_defined_ports.values.select{ |service| service.has_key? :ssl }.empty?
+    apache_params["options"] = "-DSSL"
+  end
 end
 
 pacemaker_primitive service_name do

--- a/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb
@@ -42,7 +42,7 @@ agent_name = node[:pacemaker][service_name][:agent]
 apache_params = {}
 if agent_name == "ocf:heartbeat:apache"
   apache_params["statusurl"] = "http://127.0.0.1:#{listening_port}/server-status"
-  unless crowbar_defined_ports.values.select{ |service| service.has_key? :ssl }.empty?
+  unless crowbar_defined_ports.values.select { |service| service.has_key? :ssl }.empty?
     apache_params["options"] = "-DSSL"
   end
 end


### PR DESCRIPTION
This does two things:

  - reverse the logic (ie, not checking for systemd RA) since we know
    the params we're looking at are specific to the OCF RA
  - set the SSL-related param only for the OCF RA; it was useless for
    the systemd one, afaict.