### PR TITLE
[UNTESTED] immediately abort chef-client if maintenance mode is set

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/libraries/maintenance_mode_helpers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/maintenance_mode_helpers.rb
@@ -20,7 +20,7 @@ module CrowbarPacemaker
   module MaintenanceModeHelpers
     def maintenance_mode?
       # See https://bugzilla.suse.com/show_bug.cgi?id=870696
-      !! (%x(crm_attribute -G -N #{node.hostname} -n maintenance -q) =~ /^on$/)
+      `crm_attribute -G -N #{node.hostname} -n maintenance -q` =~ /^on$/
     end
 
     def set_maintenance_mode_via_this_chef_run
@@ -32,14 +32,14 @@ module CrowbarPacemaker
       #
       # We use a default attribute so that it will get reset at the
       # beginning of each chef-client run.
-      node.default[:pacemaker][:maintenance_mode][$$][:via_chef] = true
+      node.default[:pacemaker][:maintenance_mode][$PID][:via_chef] = true
     end
 
     def maintenance_mode_set_via_this_chef_run?
       # The "== true" is required because Chef::Node::Attribute does
       # auto-vivification on read (!), so the value will be initialized
       # to an empty Chef::Node::Attribute if not already set to true.
-      node.default[:pacemaker][:maintenance_mode][$$][:via_chef] == true
+      node.default[:pacemaker][:maintenance_mode][$PID][:via_chef] == true
     end
   end
 end

--- a/chef/cookbooks/crowbar-pacemaker/libraries/maintenance_mode_helpers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/maintenance_mode_helpers.rb
@@ -23,16 +23,6 @@ module CrowbarPacemaker
       !! (%x(crm_attribute -G -N #{node.hostname} -n maintenance -q) =~ /^on$/)
     end
 
-    def record_maintenance_mode_before_this_chef_run
-      # Via Chef::Pacemaker::StartHandler we track whether anything
-      # has put the node into Pacemaker maintenance mode prior to this
-      # chef-client run.  This may come in handy during debugging.
-      #
-      # We use a default attribute so that it will get reset at the
-      # beginning of each chef-client run.
-      node.default[:pacemaker][:maintenance_mode][$$][:at_start] = maintenance_mode?
-    end
-
     def set_maintenance_mode_via_this_chef_run
       # We track whether anything has put the node into Pacemaker
       # maintenance mode during this chef-client run, so we know

--- a/chef/cookbooks/crowbar-pacemaker/recipes/maintenance-mode.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/maintenance-mode.rb
@@ -57,7 +57,7 @@ loaded = \
 if loaded
   Chef::Log.debug("Pacemaker maintenance handlers already installed")
 else
-  Chef::Log.info("Pacemaker maintenance handlers not installed; " +
+  Chef::Log.info("Pacemaker maintenance handlers not installed; " \
                  "scheduling Chef config reload")
   ruby_block "reload_chef_client_config" do
     block { Chef::Config.from_file("/etc/chef/client.rb") }


### PR DESCRIPTION
The reasoning is explained in the comments.  I'm not sure why I ever thought it was a good idea to allow a chef-client run to proceed if maintenance mode is set.  It's not even as if that approach could ever restore an ill node to full health, because we were deliberately checking whether the maintenance mode was set prior to the chef-client run, and if so, leaving it set.  This way, if a node is left in maintenance mode, it will be discovered sooner, resulting in the cloud operator being alerted to a degraded cluster sooner.

Also ported https://github.com/crowbar/barclamp-pacemaker/issues/149 on top of this.
