### PR TITLE
corosync: Start corosync-shutdown-cleaner.service on install

### DIFF
--- a/chef/cookbooks/corosync/recipes/service.rb
+++ b/chef/cookbooks/corosync/recipes/service.rb
@@ -150,7 +150,7 @@ if node[:corosync][:require_clean_for_autostart]
   end
 
   service corosync_shutdown do
-    action :enable
+    action [:enable, :start]
   end
 
   # we make sure that corosync is not enabled to start on boot


### PR DESCRIPTION
If it's not started (just enabled), then the first shutdown will not
execute its stop command, so the block file will be there and the first
boot after installing HA will fail.