### PR TITLE
reenable Pacemaker cookbook testing in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,14 @@
 language: ruby
 sudo: false
 
-rvm:
-  - 2.1.0
+matrix:
+  include:
+    - rvm: 2.1.0
+      gemfile: Gemfile
+      env: RAKEDIR=.
+    - rvm: 2.1.0
+      gemfile: chef/cookbooks/pacemaker/Gemfile
+      env: RAKEDIR=chef/cookbooks/pacemaker
+
+script: cd $RAKEDIR && bundle exec rake
+bundler_args: --without development

--- a/Gemfile
+++ b/Gemfile
@@ -22,11 +22,11 @@ group :development do
   gem "sass", "~> 3.2.19"
   gem "sprockets-standalone", "~> 1.2.1"
   gem "sprockets", "~> 2.11.0"
-  gem "rspec", "~> 3.1.0"
 end
 
 unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"
   group :test do
+    gem "rspec", "~> 3.1.0"
     gem "simplecov", require: false
 
     if ENV["CODECLIMATE_REPO_TOKEN"]

--- a/Gemfile
+++ b/Gemfile
@@ -17,10 +17,11 @@
 
 source "https://rubygems.org"
 
+gem "sprockets-standalone", "~> 1.2.1"
+
 group :development do
   gem "closure-compiler", "~> 1.1.10"
   gem "sass", "~> 3.2.19"
-  gem "sprockets-standalone", "~> 1.2.1"
   gem "sprockets", "~> 2.11.0"
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -103,7 +103,12 @@ unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"
   RSpec::Core::RakeTask.new(:spec)
 
   task :syntaxcheck do
-    system("for f in `find -name \*.rb`; do echo -n \"Syntaxcheck $f: \"; ruby -c $f || exit $? ; done")
+    system <<-'EOF'
+      for f in `find -name \*.rb`; do
+        echo -n "Syntaxcheck $f: "
+        ruby -c $f || exit $?
+      done
+    EOF
     exit $?.exitstatus
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -104,7 +104,7 @@ unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"
 
   task :syntaxcheck do
     system <<-'EOF'
-      for f in `find -name \*.rb`; do
+      for f in `find -name vendor -prune -o -name \*.rb -print`; do
         echo -n "Syntaxcheck $f: "
         ruby -c $f || exit $?
       done

--- a/chef/cookbooks/pacemaker/Gemfile
+++ b/chef/cookbooks/pacemaker/Gemfile
@@ -5,10 +5,10 @@ source "https://rubygems.org"
 group :test, :development do
   gem "chefspec", "~> 3.0"
   gem "rspec-expectations", "~> 2.14.0"
-  gem "rubydeps"
 end
 
 group :development do
+  gem "rubydeps"
   gem "foodcritic", "~> 3.0"
   gem "rubocop"
   gem "jazz_fingers"

--- a/chef/cookbooks/pacemaker/Gemfile
+++ b/chef/cookbooks/pacemaker/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 #gem 'berkshelf',  '~> 2.0'
+gem "rake"
 
 group :test, :development do
   gem "chefspec", "~> 3.0"

--- a/chef/cookbooks/pacemaker/Rakefile
+++ b/chef/cookbooks/pacemaker/Rakefile
@@ -3,7 +3,11 @@ DUMP_FILE = "rubydeps.dump"
 DOT_FILE  = "rubydeps.dot"
 SVG_FILE  = "rubydeps.svg"
 
-task default: "rubydeps:svg"
+task default: "spec"
+
+task :spec do
+  sh "rspec"
+end
 
 file DUMP_FILE do
   sh "RUBYDEPS=y rspec"


### PR DESCRIPTION
When barclamp-pacemaker was migrated to crowbar-ha, there was a
regression in the Travis CI config which meant that the pacemaker
cookbook's test suite no longer got tested.  This should fix that.