### PR TITLE
Add "role recipes" with the goal of simplifying the roles

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/metadata.rb
+++ b/chef/cookbooks/crowbar-pacemaker/metadata.rb
@@ -8,5 +8,6 @@ version "0.1"
 
 depends "drbd"
 depends "haproxy"
+depends "hawk"
 depends "lvm"
 depends "pacemaker"

--- a/chef/cookbooks/crowbar-pacemaker/recipes/role_hawk_server.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/role_hawk_server.rb
@@ -22,4 +22,6 @@ states_for_role = node[barclamp]["element_states"][role]
 
 if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
   include_recipe "hawk::server"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/crowbar-pacemaker/recipes/role_hawk_server.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/role_hawk_server.rb
@@ -1,0 +1,25 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "pacemaker"
+role = "hawk-server"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "hawk::server"
+end

--- a/chef/cookbooks/crowbar-pacemaker/recipes/role_pacemaker_cluster_member.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/role_pacemaker_cluster_member.rb
@@ -1,0 +1,25 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "pacemaker"
+role = "pacemaker-cluster-member"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "crowbar-pacemaker::default"
+end

--- a/chef/cookbooks/crowbar-pacemaker/recipes/role_pacemaker_cluster_member.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/role_pacemaker_cluster_member.rb
@@ -22,4 +22,6 @@ states_for_role = node[barclamp]["element_states"][role]
 
 if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
   include_recipe "crowbar-pacemaker::default"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/roles/hawk-server.rb
+++ b/chef/roles/hawk-server.rb
@@ -1,7 +1,5 @@
 name "hawk-server"
 description "Hawk web server"
-run_list(
-         "recipe[crowbar-pacemaker::role_hawk_server]"
-)
+run_list("recipe[crowbar-pacemaker::role_hawk_server]")
 default_attributes()
 override_attributes()

--- a/chef/roles/hawk-server.rb
+++ b/chef/roles/hawk-server.rb
@@ -1,7 +1,7 @@
 name "hawk-server"
 description "Hawk web server"
 run_list(
-         "recipe[hawk::server]"
+         "recipe[crowbar-pacemaker::role_hawk_server]"
 )
 default_attributes()
 override_attributes()

--- a/chef/roles/pacemaker-cluster-member.rb
+++ b/chef/roles/pacemaker-cluster-member.rb
@@ -1,7 +1,7 @@
 name "pacemaker-cluster-member"
 description "Pacemaker cluster member"
 run_list(
-         "recipe[crowbar-pacemaker::default]"
+         "recipe[crowbar-pacemaker::role_pacemaker_cluster_member]"
 )
 default_attributes()
 override_attributes()

--- a/chef/roles/pacemaker-cluster-member.rb
+++ b/chef/roles/pacemaker-cluster-member.rb
@@ -1,7 +1,5 @@
 name "pacemaker-cluster-member"
 description "Pacemaker cluster member"
-run_list(
-         "recipe[crowbar-pacemaker::role_pacemaker_cluster_member]"
-)
+run_list("recipe[crowbar-pacemaker::role_pacemaker_cluster_member]")
 default_attributes()
 override_attributes()


### PR DESCRIPTION
We want the roles to only reference one recipe, so that we can put some
intelligence in that recipe:

 - in a first step, we will stop changing the run list of a node
	 depending on its state, and instead have the role recipe "decide"
	 whether something should be done or not, depending on the state. This
	 will solve the issue that the search results for nodes are not
	 reliable when a node is in some state that is not "readying",
	 "applying" or "ready".

 - in a later step, we might want to have a new attribute that will tell
	 us which role to apply instead of applying everything.