### PR TITLE
Increased sync_mark timeout from 60 to 180 seconds

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/libraries/synchronization.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/synchronization.rb
@@ -57,7 +57,7 @@ require "timeout"
 module CrowbarPacemakerSynchronization
 
   # See "Synchronization helpers" documentation
-  def self.wait_for_mark_from_founder(node, mark, revision, fatal = false, timeout = 60)
+  def self.wait_for_mark_from_founder(node, mark, revision, fatal = false, timeout = 180)
     return unless CrowbarPacemakerHelper.cluster_enabled?(node)
     return if CrowbarPacemakerHelper.is_cluster_founder?(node)
 


### PR DESCRIPTION
It has been observed that non-founder members of the cluster do timeout
when waiting for founder members to complete their tasks. This patch
increases that timeout.