### PR TITLE
pacemaker: Symlink the suse templates as opensuse

### DIFF
--- a/chef/cookbooks/pacemaker/templates/opensuse/sysconfig_sbd.erb
+++ b/chef/cookbooks/pacemaker/templates/opensuse/sysconfig_sbd.erb
@@ -1,0 +1,1 @@
+../suse/sysconfig_sbd.erb

--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -32,14 +32,16 @@ class PacemakerService < ServiceObject
           "unique" => false,
           "count" => 32,
           "platform" => {
-            "suse" => "/.*/"
+            "suse" => "/.*/",
+            "opensuse" => "/.*/"
           }
         },
         "hawk-server" => {
           "unique" => false,
           "count" => -1,
           "platform" => {
-            "suse" => "/.*/"
+            "suse" => "/.*/",
+            "opensuse" => "/.*/"
           }
         }
       }


### PR DESCRIPTION
We want the same set of templates for both SUSE and openSUSE.