### PR TITLE
really increase sync_mark timeout to 300s (bsc#935462)

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/libraries/synchronization.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/synchronization.rb
@@ -57,7 +57,7 @@ require "timeout"
 module CrowbarPacemakerSynchronization
 
   # See "Synchronization helpers" documentation
-  def self.wait_for_mark_from_founder(node, mark, revision, fatal = false, timeout = 180)
+  def self.wait_for_mark_from_founder(node, mark, revision, fatal = false, timeout = 300)
     return unless CrowbarPacemakerHelper.cluster_enabled?(node)
     return if CrowbarPacemakerHelper.is_cluster_founder?(node)
 
@@ -110,7 +110,7 @@ module CrowbarPacemakerSynchronization
   end
 
   # See "Synchronization helpers" documentation
-  def self.synchronize_on_mark(node, mark, revision, fatal = false, timeout = 60)
+  def self.synchronize_on_mark(node, mark, revision, fatal = false, timeout = 300)
     return unless CrowbarPacemakerHelper.cluster_enabled?(node)
 
     cluster_name = CrowbarPacemakerHelper.cluster_name(node)

--- a/chef/cookbooks/crowbar-pacemaker/resources/sync_mark.rb
+++ b/chef/cookbooks/crowbar-pacemaker/resources/sync_mark.rb
@@ -59,4 +59,4 @@ attribute :mark,      kind_of: String,  default: nil
 attribute :revision,  kind_of: Integer, default: nil
 
 attribute :fatal,     kind_of: [TrueClass, FalseClass], default: true
-attribute :timeout,   kind_of: Integer, default: 60
+attribute :timeout,   kind_of: Integer, default: 300


### PR DESCRIPTION
d2c1a01 from #45 aimed to do this but it only changed one method's default value, and both methods' defaults are actually overridden by the default value from the LWRP resource definition.  However we make them all 180s for consistency, in the unlikely case anything else should call the methods directly in future.

https://bugzilla.suse.com/show_bug.cgi?id=935462