### PR TITLE
allow CIB objects with arbitrary unparsed definition strings

### DIFF
--- a/chef/cookbooks/pacemaker/Guardfile
+++ b/chef/cookbooks/pacemaker/Guardfile
@@ -3,7 +3,7 @@
 # More info at https://github.com/guard/guard#readme
 
 guard_opts = {
-  cmd: "bundle exec rspec --fail-fast -fd",
+  cmd: "bundle exec rspec --fail-fast",
   all_on_start:   true,
   all_after_pass: true,
   failed_mode: :focus

--- a/chef/cookbooks/pacemaker/libraries/chef/mixin/pacemaker/standard_cib_object.rb
+++ b/chef/cookbooks/pacemaker/libraries/chef/mixin/pacemaker/standard_cib_object.rb
@@ -120,6 +120,22 @@ class Chef
         ::Chef::Log.info "Successfully configured #{created_cib_object}"
       end
 
+      def standard_maybe_modify_resource(name)
+        Chef::Log.info "Checking existing #{@current_cib_object} for modifications"
+
+        desired = cib_object_class.from_chef_resource(new_resource)
+        if desired.definition_string != @current_cib_object.definition_string
+          Chef::Log.debug \
+            "changed from [#{@current_cib_object.definition_string}] " \
+            "to [#{desired.definition_string}]"
+          cmd = desired.reconfigure_command
+          execute cmd do
+            action :nothing
+          end.run_action(:run)
+          new_resource.updated_by_last_action(true)
+        end
+      end
+
       def standard_delete_resource
         execute @current_cib_object.delete_command do
           action :nothing

--- a/chef/cookbooks/pacemaker/libraries/chef/mixin/pacemaker/standard_cib_object.rb
+++ b/chef/cookbooks/pacemaker/libraries/chef/mixin/pacemaker/standard_cib_object.rb
@@ -39,7 +39,6 @@ class Chef
 
         ::Chef::Log.debug "CIB object '#{name}' currently defined as:\n#{cib_object.definition}"
         @current_resource_definition = cib_object.definition
-        cib_object.parse_definition
 
         cib_object
       end
@@ -124,10 +123,10 @@ class Chef
         Chef::Log.info "Checking existing #{@current_cib_object} for modifications"
 
         desired = cib_object_class.from_chef_resource(new_resource)
-        if desired.definition_string != @current_cib_object.definition_string
+        if desired.definition != @current_cib_object.definition
           Chef::Log.debug \
-            "changed from [#{@current_cib_object.definition_string}] " \
-            "to [#{desired.definition_string}]"
+            "changed from [#{@current_cib_object.definition}] " \
+            "to [#{desired.definition}]"
           cmd = desired.reconfigure_command
           execute cmd do
             action :nothing

--- a/chef/cookbooks/pacemaker/libraries/pacemaker/cib_object.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/cib_object.rb
@@ -14,7 +14,7 @@ module Pacemaker
         @@subclasses[type_name] = self
       end
 
-      def get_definition(name)
+      def crm_configure_show(name)
         cmd = Mixlib::ShellOut.new("crm --display=plain configure show #{name}")
         cmd.environment["HOME"] = ENV.fetch("HOME", "/root")
         cmd.run_command
@@ -27,7 +27,7 @@ module Pacemaker
       end
 
       def exists?(name)
-        get_definition(name) ? true : false
+        crm_configure_show(name) ? true : false
       end
 
       def definition_type(definition)
@@ -38,7 +38,7 @@ module Pacemaker
       end
 
       def from_name(name)
-        definition = get_definition(name)
+        definition = crm_configure_show(name)
         return nil unless definition and ! definition.empty?
         from_definition(definition)
       end
@@ -105,7 +105,7 @@ module Pacemaker
     end
 
     def load_definition
-      @definition = self.class.get_definition(name)
+      @definition = self.class.crm_configure_show(name)
 
       if @definition and ! @definition.empty? and type != self.class.object_type
         raise CIBObject::TypeMismatch, \

--- a/chef/cookbooks/pacemaker/libraries/pacemaker/constraint/colocation.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/constraint/colocation.rb
@@ -26,16 +26,19 @@ class Pacemaker::Constraint::Colocation < Pacemaker::Constraint
     # FIXME: this is incomplete.  It probably doesn't handle resource
     # sets correctly, and certainly doesn't handle node attributes.
     # See the crm(8) man page for the official BNF grammar.
-    unless definition =~ /^#{self.class.object_type} (\S+) (\d+|[-+]?inf): (.+?)\s*$/
+    # It can be fixed in the same way location has been fixed.
+    unless @definition =~
+        /^#{self.class.object_type} (\S+) (\d+|[-+]?inf): (.+?)\s*$/
       raise Pacemaker::CIBObject::DefinitionParseError, \
             "Couldn't parse definition '#{definition}'"
     end
-    self.name  = $1
+    self.name = $1
     self.score = $2
     self.resources = $3
+    attrs_authoritative
   end
 
-  def definition_string
+  def definition_from_attributes
     "#{self.class.object_type} #{name} #{score}: #{resources}"
   end
 end

--- a/chef/cookbooks/pacemaker/libraries/pacemaker/constraint/colocation.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/constraint/colocation.rb
@@ -13,7 +13,7 @@ class Pacemaker::Constraint::Colocation < Pacemaker::Constraint
     when String
       @resources = val
     else
-      raise "Tried to set resources attribute for colocation '#{name}' " +
+      raise "Tried to set resources attribute for colocation '#{name}' " \
         "to invalid type #{val.class} (#{val.inspect})"
     end
   end

--- a/chef/cookbooks/pacemaker/libraries/pacemaker/constraint/location.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/constraint/location.rb
@@ -10,20 +10,22 @@ class Pacemaker::Constraint::Location < Pacemaker::Constraint
   end
 
   def parse_definition
-    # FIXME: this is woefully incomplete, and doesn't cope with any of
-    # the rules syntax.  See the crm(8) man page for the official BNF
-    # grammar.
-    unless definition =~ /^#{self.class.object_type} (\S+) (\S+) (\d+|[-+]?inf): (\S+)\s*$/
+    unless @definition =~ /^#{self.class.object_type} (\S+) (\S.+)/
       raise Pacemaker::CIBObject::DefinitionParseError, \
             "Couldn't parse definition '#{definition}'"
     end
-    self.name  = $1
-    self.rsc   = $2
-    self.score = $3
-    self.node  = $4
+    self.name = $1
+    rest = $2
+
+    if rest =~ /(\S+) (\d+|[-+]?inf): (\S+)\s*$/
+      self.rsc = $1
+      self.score = $2
+      self.node = $3
+      attrs_authoritative
+    end
   end
 
-  def definition_string
+  def definition_from_attributes
     "#{self.class.object_type} #{name} #{rsc} #{score}: #{node}"
   end
 end

--- a/chef/cookbooks/pacemaker/libraries/pacemaker/constraint/location.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/constraint/location.rb
@@ -3,10 +3,10 @@ require_relative "../constraint"
 class Pacemaker::Constraint::Location < Pacemaker::Constraint
   register_type :location
 
-  attr_accessor :rsc, :score, :node
+  attr_accessor :rsc, :score, :lnode
 
   def self.attrs_to_copy_from_chef
-    %w(rsc score node)
+    %w(rsc score lnode)
   end
 
   def parse_definition
@@ -20,12 +20,12 @@ class Pacemaker::Constraint::Location < Pacemaker::Constraint
     if rest =~ /(\S+) (\d+|[-+]?inf): (\S+)\s*$/
       self.rsc = $1
       self.score = $2
-      self.node = $3
+      self.lnode = $3
       attrs_authoritative
     end
   end
 
   def definition_from_attributes
-    "#{self.class.object_type} #{name} #{rsc} #{score}: #{node}"
+    "#{self.class.object_type} #{name} #{rsc} #{score}: #{lnode}"
   end
 end

--- a/chef/cookbooks/pacemaker/libraries/pacemaker/constraint/order.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/constraint/order.rb
@@ -13,17 +13,19 @@ class Pacemaker::Constraint::Order < Pacemaker::Constraint
     # FIXME: add support for symmetrical=<bool>
     # Currently we take the easy way out and don't bother parsing the ordering.
     # See the crm(8) man page for the official BNF grammar.
+    # It can be fixed in the same way location has been fixed.
     score_regexp = %r{\d+|[-+]?inf|Mandatory|Optional|Serialize}
-    unless definition =~ /^#{self.class.object_type} (\S+) (#{score_regexp}): (.+?)\s*$/
+    unless @definition =~ /^#{self.class.object_type} (\S+) (#{score_regexp}): (.+?)\s*$/
       raise Pacemaker::CIBObject::DefinitionParseError, \
             "Couldn't parse definition '#{definition}'"
     end
     self.name  = $1
     self.score = $2
     self.ordering = $3
+    attrs_authoritative
   end
 
-  def definition_string
+  def definition_from_attributes
     "#{self.class.object_type} #{name} #{score}: #{ordering}"
   end
 end

--- a/chef/cookbooks/pacemaker/libraries/pacemaker/resource.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/resource.rb
@@ -7,7 +7,7 @@ module Pacemaker
     include Chef::Mixin::ShellOut
 
     def self.description
-      type = self.to_s.split("::").last.downcase
+      type = to_s.split("::").last.downcase
       "#{type} resource"
     end
 

--- a/chef/cookbooks/pacemaker/libraries/pacemaker/resource/clone.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/resource/clone.rb
@@ -14,7 +14,7 @@ class Pacemaker::Resource::Clone < Pacemaker::Resource
     %w(rsc meta)
   end
 
-  def definition_string
+  def definition_from_attributes
     str = "#{self.class.object_type} #{name} #{rsc}"
     unless meta.empty?
       str << continuation_line(meta_string)
@@ -23,12 +23,13 @@ class Pacemaker::Resource::Clone < Pacemaker::Resource
   end
 
   def parse_definition
-    unless definition =~ /^#{self.class.object_type} (\S+) (\S+)/
+    unless @definition =~ /^#{self.class.object_type} (\S+) (\S+)/
       raise Pacemaker::CIBObject::DefinitionParseError, \
             "Couldn't parse definition '#{definition}'"
     end
     self.name = $1
     self.rsc  = $2
     self.meta = self.class.extract_hash(definition, "meta")
+    attrs_authoritative
   end
 end

--- a/chef/cookbooks/pacemaker/libraries/pacemaker/resource/group.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/resource/group.rb
@@ -15,7 +15,7 @@ class Pacemaker::Resource::Group < Pacemaker::Resource
   end
 
   def parse_definition
-    unless definition =~ /^#{self.class.object_type} (\S+) (.+?)(\s+\\)?$/
+    unless @definition =~ /^#{self.class.object_type} (\S+) (.+?)(\s+\\)?$/
       raise Pacemaker::CIBObject::DefinitionParseError, \
             "Couldn't parse definition '#{definition}'"
     end
@@ -25,9 +25,11 @@ class Pacemaker::Resource::Group < Pacemaker::Resource
     members = members[0..trim_from-1] if trim_from
     self.members = members
     self.meta    = self.class.extract_hash(definition, "meta")
+
+    attrs_authoritative
   end
 
-  def definition_string
+  def definition_from_attributes
     str = "#{self.class.object_type} #{name} " + members.join(" ")
     unless meta.empty?
       str << continuation_line(meta_string)

--- a/chef/cookbooks/pacemaker/libraries/pacemaker/resource/primitive.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/resource/primitive.rb
@@ -21,24 +21,26 @@ class Pacemaker::Resource::Primitive < Pacemaker::Resource
   end
 
   def parse_definition
-    unless definition =~ /\A#{self.class.object_type} (\S+) (\S+)/
+    unless @definition =~ /\A#{self.class.object_type} (\S+) (\S+)/
       raise Pacemaker::CIBObject::DefinitionParseError, \
-            "Couldn't parse definition '#{definition}'"
+            "Couldn't parse definition '#{@definition}'"
     end
     self.name  = $1
     self.agent = $2
 
     %w(params meta).each do |data_type|
-      hash = self.class.extract_hash(definition, data_type)
+      hash = self.class.extract_hash(@definition, data_type)
       writer = (data_type + "=").to_sym
       send(writer, hash)
     end
 
     self.op = {}
     %w(start stop monitor).each do |op|
-      h = self.class.extract_hash(definition, "op #{op}")
+      h = self.class.extract_hash(@definition, "op #{op}")
       self.op[op] = h unless h.empty?
     end
+
+    attrs_authoritative
   end
 
   def params_string
@@ -49,7 +51,7 @@ class Pacemaker::Resource::Primitive < Pacemaker::Resource
     self.class.op_string(op)
   end
 
-  def definition_string
+  def definition_from_attributes
     str = "#{self.class.object_type} #{name} #{agent}"
     %w(params meta op).each do |data_type|
       unless send(data_type).empty?

--- a/chef/cookbooks/pacemaker/libraries/pacemaker/resource/primitive.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/resource/primitive.rb
@@ -63,7 +63,7 @@ class Pacemaker::Resource::Primitive < Pacemaker::Resource
   end
 
   def self.params_string(params)
-    return "" if ! params or params.empty?
+    return "" if !params || params.empty?
     "params " +
     params.sort.map do |key, value|
       safe = value.is_a?(String) ? value.gsub('"', '\\"') : value.to_s
@@ -72,7 +72,7 @@ class Pacemaker::Resource::Primitive < Pacemaker::Resource
   end
 
   def self.op_string(ops)
-    return "" if ! ops or ops.empty?
+    return "" if !ops || ops.empty?
     ops.sort.map do |op, attrs|
       attrs.empty? ? nil : "op #{op} " + \
       attrs.sort.map do |key, value|

--- a/chef/cookbooks/pacemaker/libraries/pacemaker/transaction.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/transaction.rb
@@ -12,7 +12,7 @@ module Pacemaker
     end
 
     def definition
-      cib_objects.map { |obj| obj.definition_string + "\n" }.join ""
+      cib_objects.map { |obj| obj.definition + "\n" }.join ""
     end
   end
 end

--- a/chef/cookbooks/pacemaker/providers/clone.rb
+++ b/chef/cookbooks/pacemaker/providers/clone.rb
@@ -60,15 +60,5 @@ def create_resource(name)
 end
 
 def maybe_modify_resource(name)
-  Chef::Log.info "Checking existing #{@current_cib_object} for modifications"
-
-  desired_clone = cib_object_class.from_chef_resource(new_resource)
-  if desired_clone.definition_string != @current_cib_object.definition_string
-    Chef::Log.debug "changed from [#{@current_cib_object.definition_string}] to [#{desired_clone.definition_string}]"
-    cmd = desired_clone.reconfigure_command
-    execute cmd do
-      action :nothing
-    end.run_action(:run)
-    new_resource.updated_by_last_action(true)
-  end
+  standard_maybe_modify_resource(name)
 end

--- a/chef/cookbooks/pacemaker/providers/colocation.rb
+++ b/chef/cookbooks/pacemaker/providers/colocation.rb
@@ -59,15 +59,5 @@ def create_resource(name)
 end
 
 def maybe_modify_resource(name)
-  Chef::Log.info "Checking existing #{@current_cib_object} for modifications"
-
-  desired_colocation = cib_object_class.from_chef_resource(new_resource)
-  if desired_colocation.definition_string != @current_cib_object.definition_string
-    Chef::Log.debug "changed from [#{@current_cib_object.definition_string}] to [#{desired_colocation.definition_string}]"
-    cmd = desired_colocation.reconfigure_command
-    execute cmd do
-      action :nothing
-    end.run_action(:run)
-    new_resource.updated_by_last_action(true)
-  end
+  standard_maybe_modify_resource(name)
 end

--- a/chef/cookbooks/pacemaker/providers/group.rb
+++ b/chef/cookbooks/pacemaker/providers/group.rb
@@ -59,15 +59,5 @@ def create_resource(name)
 end
 
 def maybe_modify_resource(name)
-  Chef::Log.info "Checking existing #{@current_cib_object} for modifications"
-
-  desired_group = cib_object_class.from_chef_resource(new_resource)
-  if desired_group.definition_string != @current_cib_object.definition_string
-    Chef::Log.debug "changed from [#{@current_cib_object.definition_string}] to [#{desired_group.definition_string}]"
-    cmd = desired_group.reconfigure_command
-    execute cmd do
-      action :nothing
-    end.run_action(:run)
-    new_resource.updated_by_last_action(true)
-  end
+  standard_maybe_modify_resource(name)
 end

--- a/chef/cookbooks/pacemaker/providers/location.rb
+++ b/chef/cookbooks/pacemaker/providers/location.rb
@@ -59,15 +59,5 @@ def create_resource(name)
 end
 
 def maybe_modify_resource(name)
-  Chef::Log.info "Checking existing #{@current_cib_object} for modifications"
-
-  desired_location = cib_object_class.from_chef_resource(new_resource)
-  if desired_location.definition_string != @current_cib_object.definition_string
-    Chef::Log.debug "changed from [#{@current_cib_object.definition_string}] to [#{desired_location.definition_string}]"
-    cmd = desired_location.reconfigure_command
-    execute cmd do
-      action :nothing
-    end.run_action(:run)
-    new_resource.updated_by_last_action(true)
-  end
+  standard_maybe_modify_resource(name)
 end

--- a/chef/cookbooks/pacemaker/providers/location.rb
+++ b/chef/cookbooks/pacemaker/providers/location.rb
@@ -51,7 +51,7 @@ def load_current_resource
 end
 
 def resource_attrs
-  [:rsc, :score, :node]
+  [:rsc, :score, :lnode]
 end
 
 def create_resource(name)

--- a/chef/cookbooks/pacemaker/providers/ms.rb
+++ b/chef/cookbooks/pacemaker/providers/ms.rb
@@ -60,15 +60,5 @@ def create_resource(name)
 end
 
 def maybe_modify_resource(name)
-  Chef::Log.info "Checking existing #{@current_cib_object} for modifications"
-
-  desired_clone = cib_object_class.from_chef_resource(new_resource)
-  if desired_clone.definition_string != @current_cib_object.definition_string
-    Chef::Log.debug "changed from [#{@current_cib_object.definition_string}] to [#{desired_clone.definition_string}]"
-    cmd = desired_clone.reconfigure_command
-    execute cmd do
-      action :nothing
-    end.run_action(:run)
-    new_resource.updated_by_last_action(true)
-  end
+  standard_maybe_modify_resource(name)
 end

--- a/chef/cookbooks/pacemaker/providers/order.rb
+++ b/chef/cookbooks/pacemaker/providers/order.rb
@@ -60,15 +60,5 @@ def create_resource(name)
 end
 
 def maybe_modify_resource(name)
-  Chef::Log.info "Checking existing #{@current_cib_object} for modifications"
-
-  desired_order = cib_object_class.from_chef_resource(new_resource)
-  if desired_order.definition_string != @current_cib_object.definition_string
-    Chef::Log.debug "changed from [#{@current_cib_object.definition_string}] to [#{desired_order.definition_string}]"
-    cmd = desired_order.reconfigure_command
-    execute cmd do
-      action :nothing
-    end.run_action(:run)
-    new_resource.updated_by_last_action(true)
-  end
+  standard_maybe_modify_resource(name)
 end

--- a/chef/cookbooks/pacemaker/recipes/stonith.rb
+++ b/chef/cookbooks/pacemaker/recipes/stonith.rb
@@ -157,7 +157,7 @@ when "per_node"
     pacemaker_location "l-#{stonith_resource}" do
       rsc stonith_resource
       score "-inf"
-      node node_name
+      lnode node_name
       action :create
     end
   end

--- a/chef/cookbooks/pacemaker/resources/location.rb
+++ b/chef/cookbooks/pacemaker/resources/location.rb
@@ -25,3 +25,4 @@ attribute :name,  kind_of: String, name_attribute: true
 attribute :rsc,   kind_of: String
 attribute :score, kind_of: String
 attribute :lnode, kind_of: String
+attribute :definition, kind_of: String

--- a/chef/cookbooks/pacemaker/resources/location.rb
+++ b/chef/cookbooks/pacemaker/resources/location.rb
@@ -24,4 +24,4 @@ default_action :create
 attribute :name,  kind_of: String, name_attribute: true
 attribute :rsc,   kind_of: String
 attribute :score, kind_of: String
-attribute :node,  kind_of: String
+attribute :lnode, kind_of: String

--- a/chef/cookbooks/pacemaker/spec/fixtures/clone_resource.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/clone_resource.rb
@@ -11,6 +11,7 @@ class Chef
           ["clone-max",       "2"],
           ["clone-node-max",  "2"]
         ]
+        CLONE_RESOURCE.attrs_authoritative
         CLONE_RESOURCE_DEFINITION = <<'EOF'.chomp
 clone clone1 primitive1 \
          meta clone-max="2" clone-node-max="2" globally-unique="true"

--- a/chef/cookbooks/pacemaker/spec/fixtures/colocation_constraint.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/colocation_constraint.rb
@@ -8,6 +8,7 @@ class Chef
           ::Pacemaker::Constraint::Colocation.new("colocation1")
         COLOCATION_CONSTRAINT.score = "inf"
         COLOCATION_CONSTRAINT.resources = "rsc1 rsc2"
+        COLOCATION_CONSTRAINT.attrs_authoritative
         COLOCATION_CONSTRAINT_DEFINITION = "colocation colocation1 inf: rsc1 rsc2"
       end
     end

--- a/chef/cookbooks/pacemaker/spec/fixtures/colocation_constraint.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/colocation_constraint.rb
@@ -4,8 +4,8 @@ class Chef
   module RSpec
     module Pacemaker
       module Config
-        COLOCATION_CONSTRAINT = \
-        ::Pacemaker::Constraint::Colocation.new("colocation1")
+        COLOCATION_CONSTRAINT =
+          ::Pacemaker::Constraint::Colocation.new("colocation1")
         COLOCATION_CONSTRAINT.score = "inf"
         COLOCATION_CONSTRAINT.resources = "rsc1 rsc2"
         COLOCATION_CONSTRAINT_DEFINITION = "colocation colocation1 inf: rsc1 rsc2"

--- a/chef/cookbooks/pacemaker/spec/fixtures/cookbooks/pacemaker_test/recipes/keystone_location.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/cookbooks/pacemaker_test/recipes/keystone_location.rb
@@ -6,7 +6,7 @@ pacemaker_location Chef::RSpec::Pacemaker::Config::KEYSTONE_LOCATION_NAME do
 
   rsc location.rsc
   score location.score
-  node location.node
+  lnode location.lnode
 
   action :nothing
 end

--- a/chef/cookbooks/pacemaker/spec/fixtures/keystone_clone.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/keystone_clone.rb
@@ -13,6 +13,7 @@ class Chef
           ["clone-max",       "2"],
           ["clone-node-max",  "1"]
         ]
+        KEYSTONE_CLONE.attrs_authoritative
         KEYSTONE_CLONE_DEFINITION = <<'EOF'.chomp
 clone cl-keystone keystone \
          meta clone-max="2" clone-node-max="1" globally-unique="true"

--- a/chef/cookbooks/pacemaker/spec/fixtures/keystone_location.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/keystone_location.rb
@@ -5,8 +5,8 @@ class Chef
     module Pacemaker
       module Config
         KEYSTONE_LOCATION_NAME = "l-keystone"
-        KEYSTONE_LOCATION = \
-        ::Pacemaker::Constraint::Location.new(KEYSTONE_LOCATION_NAME)
+        KEYSTONE_LOCATION =
+          ::Pacemaker::Constraint::Location.new(KEYSTONE_LOCATION_NAME)
         KEYSTONE_LOCATION.rsc   = "keystone"
         KEYSTONE_LOCATION.score = "-inf"
         KEYSTONE_LOCATION.node  = "node1"

--- a/chef/cookbooks/pacemaker/spec/fixtures/keystone_location.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/keystone_location.rb
@@ -7,9 +7,9 @@ class Chef
         KEYSTONE_LOCATION_NAME = "l-keystone"
         KEYSTONE_LOCATION =
           ::Pacemaker::Constraint::Location.new(KEYSTONE_LOCATION_NAME)
-        KEYSTONE_LOCATION.rsc   = "keystone"
+        KEYSTONE_LOCATION.rsc = "keystone"
         KEYSTONE_LOCATION.score = "-inf"
-        KEYSTONE_LOCATION.node  = "node1"
+        KEYSTONE_LOCATION.lnode = "node1"
         KEYSTONE_LOCATION.attrs_authoritative
         KEYSTONE_LOCATION_DEFINITION = "location l-keystone keystone -inf: node1"
       end

--- a/chef/cookbooks/pacemaker/spec/fixtures/keystone_location.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/keystone_location.rb
@@ -10,6 +10,7 @@ class Chef
         KEYSTONE_LOCATION.rsc   = "keystone"
         KEYSTONE_LOCATION.score = "-inf"
         KEYSTONE_LOCATION.node  = "node1"
+        KEYSTONE_LOCATION.attrs_authoritative
         KEYSTONE_LOCATION_DEFINITION = "location l-keystone keystone -inf: node1"
       end
     end

--- a/chef/cookbooks/pacemaker/spec/fixtures/keystone_primitive.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/keystone_primitive.rb
@@ -25,6 +25,7 @@ class Chef
           ["monitor", { "timeout" =>  "60", "interval" => "10s" }],
           ["start",   { "timeout" => "240", "interval" => "10s" }]
         ]
+        KEYSTONE_PRIMITIVE.attrs_authoritative
         KEYSTONE_PRIMITIVE_DEFINITION = <<'EOF'.chomp
 primitive keystone ocf:openstack:keystone \
          params os_auth_url="http://node1:5000/v2.0" os_password="ad\"min$pa&ss'wo%rd" os_tenant_name="openstack" os_username="admin" user="openstack-keystone" \

--- a/chef/cookbooks/pacemaker/spec/fixtures/location_constraint.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/location_constraint.rb
@@ -4,8 +4,8 @@ class Chef
   module RSpec
     module Pacemaker
       module Config
-        LOCATION_CONSTRAINT = \
-        ::Pacemaker::Constraint::Location.new("location1")
+        LOCATION_CONSTRAINT =
+          ::Pacemaker::Constraint::Location.new("location1")
         LOCATION_CONSTRAINT.rsc   = "primitive1"
         LOCATION_CONSTRAINT.score = "-inf"
         LOCATION_CONSTRAINT.node  = "node1"

--- a/chef/cookbooks/pacemaker/spec/fixtures/location_constraint.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/location_constraint.rb
@@ -9,6 +9,7 @@ class Chef
         LOCATION_CONSTRAINT.rsc   = "primitive1"
         LOCATION_CONSTRAINT.score = "-inf"
         LOCATION_CONSTRAINT.node  = "node1"
+        LOCATION_CONSTRAINT.attrs_authoritative
         LOCATION_CONSTRAINT_DEFINITION = "location location1 primitive1 -inf: node1"
       end
     end

--- a/chef/cookbooks/pacemaker/spec/fixtures/location_constraint.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/location_constraint.rb
@@ -6,9 +6,9 @@ class Chef
       module Config
         LOCATION_CONSTRAINT =
           ::Pacemaker::Constraint::Location.new("location1")
-        LOCATION_CONSTRAINT.rsc   = "primitive1"
+        LOCATION_CONSTRAINT.rsc = "primitive1"
         LOCATION_CONSTRAINT.score = "-inf"
-        LOCATION_CONSTRAINT.node  = "node1"
+        LOCATION_CONSTRAINT.lnode = "node1"
         LOCATION_CONSTRAINT.attrs_authoritative
         LOCATION_CONSTRAINT_DEFINITION = "location location1 primitive1 -inf: node1"
       end

--- a/chef/cookbooks/pacemaker/spec/fixtures/location_rule_constraint.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/location_rule_constraint.rb
@@ -1,0 +1,20 @@
+require_relative "../../libraries/pacemaker/constraint/location"
+
+class Chef
+  module RSpec
+    module Pacemaker
+      module Config
+        LOCATION_RULE_CONSTRAINT_NAME = "rulelocation1"
+        LOCATION_RULE_CONSTRAINT_DEFINITION =
+          "location #{LOCATION_RULE_CONSTRAINT_NAME} " \
+          "primitive1 resource-discovery=exclusive " \
+          "rule 0: OpenStack-role eq controller"
+
+        LOCATION_RULE_CONSTRAINT =
+          ::Pacemaker::Constraint::Location.new(LOCATION_RULE_CONSTRAINT_NAME)
+        LOCATION_RULE_CONSTRAINT.definition =
+          LOCATION_RULE_CONSTRAINT_DEFINITION
+      end
+    end
+  end
+end

--- a/chef/cookbooks/pacemaker/spec/fixtures/ms_resource.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/ms_resource.rb
@@ -13,6 +13,7 @@ class Chef
           ["master-max",      "1"],
           ["master-node-max", "1"]
         ]
+        MS_RESOURCE.attrs_authoritative
         MS_RESOURCE_DEFINITION = <<'EOF'.chomp
 ms ms1 primitive1 \
          meta clone-max="2" clone-node-max="2" globally-unique="true" master-max="1" master-node-max="1"

--- a/chef/cookbooks/pacemaker/spec/fixtures/order_constraint.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/order_constraint.rb
@@ -8,6 +8,7 @@ class Chef
           ::Pacemaker::Constraint::Order.new("order1")
         ORDER_CONSTRAINT.score = "Mandatory"
         ORDER_CONSTRAINT.ordering = "primitive1 clone1"
+        ORDER_CONSTRAINT.attrs_authoritative
         ORDER_CONSTRAINT_DEFINITION = "order order1 Mandatory: primitive1 clone1"
       end
     end

--- a/chef/cookbooks/pacemaker/spec/fixtures/order_constraint.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/order_constraint.rb
@@ -4,8 +4,8 @@ class Chef
   module RSpec
     module Pacemaker
       module Config
-        ORDER_CONSTRAINT = \
-        ::Pacemaker::Constraint::Order.new("order1")
+        ORDER_CONSTRAINT =
+          ::Pacemaker::Constraint::Order.new("order1")
         ORDER_CONSTRAINT.score = "Mandatory"
         ORDER_CONSTRAINT.ordering = "primitive1 clone1"
         ORDER_CONSTRAINT_DEFINITION = "order order1 Mandatory: primitive1 clone1"

--- a/chef/cookbooks/pacemaker/spec/fixtures/resource_group.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/resource_group.rb
@@ -10,6 +10,7 @@ class Chef
         RESOURCE_GROUP.meta = [
           ["is-managed", "true"]
         ]
+        RESOURCE_GROUP.attrs_authoritative
         RESOURCE_GROUP_DEFINITION = <<'EOF'.chomp
 group group1 resource1 resource2 \
          meta is-managed="true"

--- a/chef/cookbooks/pacemaker/spec/fixtures/resource_group.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/resource_group.rb
@@ -4,8 +4,8 @@ class Chef
   module RSpec
     module Pacemaker
       module Config
-        RESOURCE_GROUP = \
-        ::Pacemaker::Resource::Group.new("group1")
+        RESOURCE_GROUP =
+          ::Pacemaker::Resource::Group.new("group1")
         RESOURCE_GROUP.members = ["resource1", "resource2"]
         RESOURCE_GROUP.meta = [
           ["is-managed", "true"]

--- a/chef/cookbooks/pacemaker/spec/helpers/cib_object.rb
+++ b/chef/cookbooks/pacemaker/spec/helpers/cib_object.rb
@@ -21,14 +21,24 @@ shared_examples "a CIB object" do
   end
 
   it "should instantiate by parsing a definition" do
-    obj = Pacemaker::CIBObject.from_definition(fixture.definition_string)
+    obj = Pacemaker::CIBObject.from_definition(fixture.definition)
     expect_to_match_fixture(obj)
   end
 
-  it "should barf if the loaded definition's type is not right" do
+  it "should barf if the definition's type is not registered" do
     mock_existing_cib_object(fixture.name, "sometype #{fixture.name} blah blah")
-    expect { fixture.load_definition }.to \
-      raise_error(Pacemaker::CIBObject::TypeMismatch,
-                  "Expected #{object_type} type but loaded definition was type sometype")
+    expect { Pacemaker::CIBObject.from_name(fixture.name) }.to raise_error(
+      RuntimeError,
+      "No subclass of Pacemaker::CIBObject was registered with type 'sometype'"
+    )
+  end
+
+  it "should barf if the definition's type is not right" do
+    expect {
+      fixture.definition = "sometype #{fixture.name} blah blah"
+    }.to raise_error(
+      Pacemaker::CIBObject::TypeMismatch,
+      "Expected #{object_type} type but loaded definition was type sometype"
+    )
   end
 end

--- a/chef/cookbooks/pacemaker/spec/helpers/crm_mocks.rb
+++ b/chef/cookbooks/pacemaker/spec/helpers/crm_mocks.rb
@@ -52,7 +52,7 @@ class Chef
         end
 
         def mock_existing_cib_object_from_fixture(fixture)
-          mock_existing_cib_object(fixture.name, fixture.definition_string)
+          mock_existing_cib_object(fixture.name, fixture.definition)
         end
 
         def mock_nonexistent_cib_object(name)

--- a/chef/cookbooks/pacemaker/spec/helpers/runnable_resource.rb
+++ b/chef/cookbooks/pacemaker/spec/helpers/runnable_resource.rb
@@ -88,7 +88,7 @@ shared_examples "a runnable resource" do |fixture|
     end
 
     it "should start a stopped resource" do
-      config = fixture.definition_string.sub("Started", "Stopped")
+      config = fixture.definition.sub("Started", "Stopped")
       mock_existing_cib_object(fixture.name, config)
       expect_running(false)
 
@@ -107,7 +107,7 @@ shared_examples "a runnable resource" do |fixture|
                           "Cannot stop non-existent #{fixture}"
 
     it "should do nothing to a stopped resource" do
-      config = fixture.definition_string.sub("Started", "Stopped")
+      config = fixture.definition.sub("Started", "Stopped")
       mock_existing_cib_object(fixture.name, config)
       expect_running(false)
 

--- a/chef/cookbooks/pacemaker/spec/helpers/shellout.rb
+++ b/chef/cookbooks/pacemaker/spec/helpers/shellout.rb
@@ -13,9 +13,11 @@ module Chef::RSpec
         expect(::Mixlib::ShellOut).
           to receive(:new).with(opts[:command]).and_return(double)
         if ENV["DEBUG_MIXLIB_SHELLOUT"]
-          puts "expecting [#{opts[:command]}]"
-          puts "to yield [#{opts[:stdout]}, #{opts[:stderr]}, #{opts[:exitstatus]}]"
-          puts "double #{double.object_id}"
+          puts "expecting [#{opts[:command]}] to yield:"
+          puts "  stdout: [#{opts[:stdout]}]"
+          puts "  stderr: [#{opts[:stderr]}]"
+          puts "  exit code: [#{opts[:exitstatus]}]"
+          puts "double object id: #{double.object_id}"
         end
       end
 

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/cib_object_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/cib_object_spec.rb
@@ -8,46 +8,36 @@ require_relative "../../fixtures/keystone_primitive"
 describe Pacemaker::CIBObject do
   include Chef::RSpec::Pacemaker::Mocks
 
-  let(:cib_object) { Chef::RSpec::Pacemaker::Config::KEYSTONE_PRIMITIVE.dup }
+  let(:fixture) { Chef::RSpec::Pacemaker::Config::KEYSTONE_PRIMITIVE.dup }
 
   #####################################################################
   # examples start here
 
   context "with no CIB object" do
     before(:each) do
-      mock_nonexistent_cib_object(cib_object.name)
+      mock_nonexistent_cib_object(fixture.name)
     end
 
-    describe "#load_definition" do
+    describe "::from_name" do
       it "should return nil" do
-        cib_object.load_definition
-        expect(cib_object.definition).to eq(nil)
-      end
-    end
-
-    describe "#exists?" do
-      it "should return false" do
-        cib_object.load_definition
-        expect(cib_object.exists?).to be_false
+        expect(::Pacemaker::CIBObject.from_name(fixture.name)).to eq(nil)
       end
     end
 
     describe ".exists?" do
       it "should return false" do
-        expect(::Pacemaker::CIBObject.exists?(cib_object.name)).to be_false
+        expect(::Pacemaker::CIBObject.exists?(fixture.name)).to be_false
       end
     end
   end
 
   context "keystone primitive resource CIB object" do
     before(:each) do
-      mock_existing_cib_object_from_fixture(cib_object)
+      mock_existing_cib_object_from_fixture(fixture)
     end
 
-    context "with definition loaded" do
-      before(:each) do
-        cib_object.load_definition
-      end
+    context "loaded from CIB" do
+      let(:cib_object) { ::Pacemaker::CIBObject.from_name(fixture.name) }
 
       describe "#exists?" do
         it "should return true" do
@@ -57,7 +47,7 @@ describe Pacemaker::CIBObject do
 
       describe "#load_definition" do
         it "should retrieve cluster config" do
-          expect(cib_object.definition).to eq(cib_object.definition_string)
+          expect(cib_object.definition).to eq(fixture.definition)
         end
       end
 
@@ -70,34 +60,37 @@ describe Pacemaker::CIBObject do
 
     describe ".exists?" do
       it "should return true" do
-        expect(::Pacemaker::CIBObject.exists?(cib_object.name)).to be_true
+        expect(::Pacemaker::CIBObject.exists?(fixture.name)).to be_true
       end
     end
   end
 
   context "CIB object with unregistered type" do
     before(:each) do
-      mock_existing_cib_object(cib_object.name, "unregistered #{cib_object.name} <definition>")
+      mock_existing_cib_object(fixture.name, "unregistered #{fixture.name} <definition>")
     end
 
     describe "::from_name" do
       it "should refuse to instantiate from any subclass" do
-        expect {
-          Pacemaker::CIBObject.from_name(cib_object.name)
-        }.to raise_error "No subclass of Pacemaker::CIBObject was registered with type 'unregistered'"
+        expect { ::Pacemaker::CIBObject.from_name(fixture.name) }.
+          to raise_error \
+            "No subclass of Pacemaker::CIBObject was registered with type 'unregistered'"
       end
     end
   end
 
   context "invalid CIB object definition" do
     before(:each) do
-      mock_existing_cib_object(cib_object.name, "nonsense")
+      mock_existing_cib_object(fixture.name, "nonsense")
     end
 
     describe "#type" do
       it "should raise an error without a valid definition" do
-        expect { cib_object.load_definition }.to \
-          raise_error(RuntimeError, "Couldn't extract CIB object type from 'nonsense'")
+        expect { ::Pacemaker::CIBObject.from_name(fixture.name) }.
+          to raise_error(
+            RuntimeError,
+            "Couldn't extract CIB object type from 'nonsense'"
+          )
       end
     end
   end

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/cib_object_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/cib_object_spec.rb
@@ -28,13 +28,13 @@ describe Pacemaker::CIBObject do
     describe "#exists?" do
       it "should return false" do
         cib_object.load_definition
-        expect(cib_object.exists?).to be(false)
+        expect(cib_object.exists?).to be_false
       end
     end
 
     describe ".exists?" do
       it "should return false" do
-        expect(::Pacemaker::CIBObject.exists?(cib_object.name)).to be(false)
+        expect(::Pacemaker::CIBObject.exists?(cib_object.name)).to be_false
       end
     end
   end
@@ -51,7 +51,7 @@ describe Pacemaker::CIBObject do
 
       describe "#exists?" do
         it "should return true" do
-          expect(cib_object.exists?).to be(true)
+          expect(cib_object.exists?).to be_true
         end
       end
 
@@ -70,7 +70,7 @@ describe Pacemaker::CIBObject do
 
     describe ".exists?" do
       it "should return true" do
-        expect(::Pacemaker::CIBObject.exists?(cib_object.name)).to be(true)
+        expect(::Pacemaker::CIBObject.exists?(cib_object.name)).to be_true
       end
     end
   end

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/constraint/colocation_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/constraint/colocation_spec.rb
@@ -6,9 +6,9 @@ require_relative "../../../helpers/cib_object"
 
 describe Pacemaker::Constraint::Colocation do
   let(:fixture) { Chef::RSpec::Pacemaker::Config::COLOCATION_CONSTRAINT.dup }
-  let(:fixture_definition) {
+  let(:fixture_definition) do
     Chef::RSpec::Pacemaker::Config::COLOCATION_CONSTRAINT_DEFINITION
-  }
+  end
 
   def object_type
     "colocation"

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/constraint/colocation_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/constraint/colocation_spec.rb
@@ -38,27 +38,28 @@ describe Pacemaker::Constraint::Colocation do
     it "should accept an String of resources" do
       @colocation.resources = @resource_string
       expect(@colocation.resources).to eq(@resource_string)
-      expect(@colocation.definition_string).to eq(@definition_string)
+      @colocation.attrs_authoritative
+      expect(@colocation.definition).to eq(@definition_string)
     end
 
     it "should accept an Array of resources" do
       @colocation.resources = @resource_array
       expect(@colocation.resources).to eq(@resource_string)
-      expect(@colocation.definition_string).to eq(@definition_string)
+      @colocation.attrs_authoritative
+      expect(@colocation.definition).to eq(@definition_string)
     end
   end
 
-  describe "#definition_string" do
+  describe "#definition" do
     it "should return the definition string" do
-      expect(fixture.definition_string).to eq(fixture_definition)
+      expect(fixture.definition).to eq(fixture_definition)
     end
 
     it "should return a short definition string" do
       colocation = pacemaker_object_class.new("foo")
       colocation.definition = \
         %!colocation colocation1 -inf: rsc1 rsc2!
-      colocation.parse_definition
-      expect(colocation.definition_string).to eq(<<'EOF'.chomp)
+      expect(colocation.definition).to eq(<<'EOF'.chomp)
 colocation colocation1 -inf: rsc1 rsc2
 EOF
     end
@@ -68,7 +69,6 @@ EOF
     before(:each) do
       @parsed = pacemaker_object_class.new(fixture.name)
       @parsed.definition = fixture_definition
-      @parsed.parse_definition
     end
 
     it "should parse the score" do

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/constraint/location_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/constraint/location_spec.rb
@@ -16,9 +16,9 @@ describe Pacemaker::Constraint::Location do
 
   context "simple location constraint" do
     let(:fixture) { Chef::RSpec::Pacemaker::Config::LOCATION_CONSTRAINT.dup }
-    let(:fixture_definition) {
+    let(:fixture_definition) do
       Chef::RSpec::Pacemaker::Config::LOCATION_CONSTRAINT_DEFINITION
-    }
+    end
 
     def fields
       %w(name rsc score node)
@@ -63,9 +63,9 @@ EOF
 
   context "rule-based constraint" do
     let(:fixture) { Chef::RSpec::Pacemaker::Config::LOCATION_RULE_CONSTRAINT.dup }
-    let(:fixture_definition) {
+    let(:fixture_definition) do
       Chef::RSpec::Pacemaker::Config::LOCATION_RULE_CONSTRAINT_DEFINITION
-    }
+    end
 
     def fields
       %w(name definition)

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/constraint/location_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/constraint/location_spec.rb
@@ -2,14 +2,10 @@ require "spec_helper"
 
 require_relative "../../../../libraries/pacemaker/constraint/location"
 require_relative "../../../fixtures/location_constraint"
+require_relative "../../../fixtures/location_rule_constraint"
 require_relative "../../../helpers/cib_object"
 
 describe Pacemaker::Constraint::Location do
-  let(:fixture) { Chef::RSpec::Pacemaker::Config::LOCATION_CONSTRAINT.dup }
-  let(:fixture_definition) {
-    Chef::RSpec::Pacemaker::Config::LOCATION_CONSTRAINT_DEFINITION
-  }
-
   def object_type
     "location"
   end
@@ -18,45 +14,86 @@ describe Pacemaker::Constraint::Location do
     Pacemaker::Constraint::Location
   end
 
-  def fields
-    %w(name rsc score node)
-  end
+  context "simple location constraint" do
+    let(:fixture) { Chef::RSpec::Pacemaker::Config::LOCATION_CONSTRAINT.dup }
+    let(:fixture_definition) {
+      Chef::RSpec::Pacemaker::Config::LOCATION_CONSTRAINT_DEFINITION
+    }
 
-  it_should_behave_like "a CIB object"
-
-  describe "#definition_string" do
-    it "should return the definition string" do
-      expect(fixture.definition_string).to eq(fixture_definition)
+    def fields
+      %w(name rsc score node)
     end
 
-    it "should return a short definition string" do
-      location = pacemaker_object_class.new("foo")
-      location.definition = \
-        %!location location1 primitive1 -inf: node1!
-      location.parse_definition
-      expect(location.definition_string).to eq(<<'EOF'.chomp)
+    it_should_behave_like "a CIB object"
+
+    describe "#definition" do
+      it "should return the definition string" do
+        expect(fixture.definition).to eq(fixture_definition)
+      end
+
+      it "should return a short definition string" do
+        location = pacemaker_object_class.new("foo")
+        location.definition =
+          %!location location1 primitive1 -inf: node1!
+        expect(location.definition).to eq(<<'EOF'.chomp)
 location location1 primitive1 -inf: node1
 EOF
+      end
+    end
+
+    describe "#parse_definition" do
+      before(:each) do
+        @parsed = pacemaker_object_class.new(fixture.name)
+        @parsed.definition = fixture_definition
+      end
+
+      it "should parse the rsc" do
+        expect(@parsed.rsc).to eq(fixture.rsc)
+      end
+
+      it "should parse the score" do
+        expect(@parsed.score).to eq(fixture.score)
+      end
+
+      it "should parse the node" do
+        expect(@parsed.node).to eq(fixture.node)
+      end
     end
   end
 
-  describe "#parse_definition" do
-    before(:each) do
-      @parsed = pacemaker_object_class.new(fixture.name)
-      @parsed.definition = fixture_definition
-      @parsed.parse_definition
+  context "rule-based constraint" do
+    let(:fixture) { Chef::RSpec::Pacemaker::Config::LOCATION_RULE_CONSTRAINT.dup }
+    let(:fixture_definition) {
+      Chef::RSpec::Pacemaker::Config::LOCATION_RULE_CONSTRAINT_DEFINITION
+    }
+
+    def fields
+      %w(name definition)
     end
 
-    it "should parse the rsc" do
-      expect(@parsed.rsc).to eq(fixture.rsc)
+    describe "with arbitrary definition" do
+      before(:each) do
+        @obj = pacemaker_object_class.new(fixture.name)
+        @obj.definition = fixture_definition
+      end
+
+      it "should return an unparsed definition string" do
+        expect(@obj.definition).to eq(fixture_definition)
+      end
+
+      it "should not return a rsc attribute" do
+        expect(@obj.rsc).to be_nil
+      end
+
+      it "should not return a score attribute" do
+        expect(@obj.score).to be_nil
+      end
+
+      it "should not return a node attribute" do
+        expect(@obj.node).to be_nil
+      end
     end
 
-    it "should parse the score" do
-      expect(@parsed.score).to eq(fixture.score)
-    end
-
-    it "should parse the node" do
-      expect(@parsed.node).to eq(fixture.node)
-    end
+    it_should_behave_like "a CIB object"
   end
 end

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/constraint/location_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/constraint/location_spec.rb
@@ -21,7 +21,7 @@ describe Pacemaker::Constraint::Location do
     end
 
     def fields
-      %w(name rsc score node)
+      %w(name rsc score lnode)
     end
 
     it_should_behave_like "a CIB object"
@@ -56,7 +56,7 @@ EOF
       end
 
       it "should parse the node" do
-        expect(@parsed.node).to eq(fixture.node)
+        expect(@parsed.lnode).to eq(fixture.lnode)
       end
     end
   end
@@ -89,8 +89,8 @@ EOF
         expect(@obj.score).to be_nil
       end
 
-      it "should not return a node attribute" do
-        expect(@obj.node).to be_nil
+      it "should not return an lnode attribute" do
+        expect(@obj.lnode).to be_nil
       end
     end
 

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/constraint/order_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/constraint/order_spec.rb
@@ -6,9 +6,9 @@ require_relative "../../../helpers/cib_object"
 
 describe Pacemaker::Constraint::Order do
   let(:fixture) { Chef::RSpec::Pacemaker::Config::ORDER_CONSTRAINT.dup }
-  let(:fixture_definition) {
+  let(:fixture_definition) do
     Chef::RSpec::Pacemaker::Config::ORDER_CONSTRAINT_DEFINITION
-  }
+  end
 
   def object_type
     "order"

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/constraint/order_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/constraint/order_spec.rb
@@ -24,17 +24,16 @@ describe Pacemaker::Constraint::Order do
 
   it_should_behave_like "a CIB object"
 
-  describe "#definition_string" do
+  describe "#definition" do
     it "should return the definition string" do
-      expect(fixture.definition_string).to eq(fixture_definition)
+      expect(fixture.definition).to eq(fixture_definition)
     end
 
     it "should return a short definition string" do
       order = pacemaker_object_class.new("foo")
       order.definition = \
         %!order order1 Mandatory: rsc1 rsc2!
-      order.parse_definition
-      expect(order.definition_string).to eq(<<'EOF'.chomp)
+      expect(order.definition).to eq(<<'EOF'.chomp)
 order order1 Mandatory: rsc1 rsc2
 EOF
     end
@@ -44,7 +43,6 @@ EOF
     before(:each) do
       @parsed = pacemaker_object_class.new(fixture.name)
       @parsed.definition = fixture_definition
-      @parsed.parse_definition
     end
 
     it "should parse the score" do

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/clone_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/clone_spec.rb
@@ -27,17 +27,16 @@ describe Pacemaker::Resource::Clone do
 
   it_should_behave_like "with meta attributes"
 
-  describe "#definition_string" do
+  describe "#definition" do
     it "should return the definition string" do
-      expect(fixture.definition_string).to eq(fixture_definition)
+      expect(fixture.definition).to eq(fixture_definition)
     end
 
     it "should return a short definition string" do
       clone = pacemaker_object_class.new("foo")
       clone.definition = \
         %!clone clone1 primitive1 meta globally-unique="true"!
-      clone.parse_definition
-      expect(clone.definition_string).to eq(<<'EOF'.chomp)
+      expect(clone.definition).to eq(<<'EOF'.chomp)
 clone clone1 primitive1 \
          meta globally-unique="true"
 EOF
@@ -48,7 +47,6 @@ EOF
     before(:each) do
       @parsed = pacemaker_object_class.new(fixture.name)
       @parsed.definition = fixture_definition
-      @parsed.parse_definition
     end
 
     it "should parse the rsc" do

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/clone_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/clone_spec.rb
@@ -7,9 +7,9 @@ require_relative "../../../helpers/meta_examples"
 
 describe Pacemaker::Resource::Clone do
   let(:fixture) { Chef::RSpec::Pacemaker::Config::CLONE_RESOURCE.dup }
-  let(:fixture_definition) {
+  let(:fixture_definition) do
     Chef::RSpec::Pacemaker::Config::CLONE_RESOURCE_DEFINITION
-  }
+  end
 
   def object_type
     "clone"

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/group_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/group_spec.rb
@@ -7,9 +7,9 @@ require_relative "../../../helpers/meta_examples"
 
 describe Pacemaker::Resource::Group do
   let(:fixture) { Chef::RSpec::Pacemaker::Config::RESOURCE_GROUP.dup }
-  let(:fixture_definition) {
+  let(:fixture_definition) do
     Chef::RSpec::Pacemaker::Config::RESOURCE_GROUP_DEFINITION
-  }
+  end
 
   def object_type
     "group"

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/group_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/group_spec.rb
@@ -27,17 +27,16 @@ describe Pacemaker::Resource::Group do
 
   it_should_behave_like "with meta attributes"
 
-  describe "#definition_string" do
+  describe "#definition" do
     it "should return the definition string" do
-      expect(fixture.definition_string).to eq(fixture_definition)
+      expect(fixture.definition).to eq(fixture_definition)
     end
 
     it "should return a short definition string" do
       group = pacemaker_object_class.new("foo")
       group.definition = \
         %!group foo member1 member2 meta target-role="Started"!
-      group.parse_definition
-      expect(group.definition_string).to eq(<<'EOF'.chomp)
+      expect(group.definition).to eq(<<'EOF'.chomp)
 group foo member1 member2 \
          meta target-role="Started"
 EOF
@@ -48,7 +47,6 @@ EOF
     before(:each) do
       @parsed = pacemaker_object_class.new(fixture.name)
       @parsed.definition = fixture_definition
-      @parsed.parse_definition
     end
 
     it "should parse the members" do

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/ms_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/ms_spec.rb
@@ -27,17 +27,16 @@ describe Pacemaker::Resource::MasterSlave do
 
   it_should_behave_like "with meta attributes"
 
-  describe "#definition_string" do
+  describe "#definition" do
     it "should return the definition string" do
-      expect(fixture.definition_string).to eq(fixture_definition)
+      expect(fixture.definition).to eq(fixture_definition)
     end
 
     it "should return a short definition string" do
       ms = pacemaker_object_class.new("foo")
       ms.definition = \
         %!ms ms1 primitive1 meta globally-unique="true"!
-      ms.parse_definition
-      expect(ms.definition_string).to eq(<<'EOF'.chomp)
+      expect(ms.definition).to eq(<<'EOF'.chomp)
 ms ms1 primitive1 \
          meta globally-unique="true"
 EOF
@@ -48,7 +47,6 @@ EOF
     before(:each) do
       @parsed = pacemaker_object_class.new(fixture.name)
       @parsed.definition = fixture_definition
-      @parsed.parse_definition
     end
 
     it "should parse the rsc" do

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/ms_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/ms_spec.rb
@@ -7,9 +7,9 @@ require_relative "../../../helpers/meta_examples"
 
 describe Pacemaker::Resource::MasterSlave do
   let(:fixture) { Chef::RSpec::Pacemaker::Config::MS_RESOURCE.dup }
-  let(:fixture_definition) {
+  let(:fixture_definition) do
     Chef::RSpec::Pacemaker::Config::MS_RESOURCE_DEFINITION
-  }
+  end
 
   def object_type
     "ms"

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/primitive_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/primitive_spec.rb
@@ -7,9 +7,9 @@ require_relative "../../../helpers/meta_examples"
 
 describe Pacemaker::Resource::Primitive do
   let(:fixture) { Chef::RSpec::Pacemaker::Config::KEYSTONE_PRIMITIVE.dup }
-  let(:fixture_definition) {
+  let(:fixture_definition) do
     Chef::RSpec::Pacemaker::Config::KEYSTONE_PRIMITIVE_DEFINITION
-  }
+  end
 
   def object_type
     "primitive"

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/primitive_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/primitive_spec.rb
@@ -69,32 +69,30 @@ describe Pacemaker::Resource::Primitive do
 
   it_should_behave_like "with meta attributes"
 
-  describe "#definition_string" do
+  describe "#definition" do
     it "should return the definition string" do
-      expect(fixture.definition_string).to eq(fixture_definition)
+      expect(fixture.definition).to eq(fixture_definition)
     end
 
     it "should return a short definition string" do
       primitive = pacemaker_object_class.new("foo")
       primitive.definition = \
         %!primitive foo ocf:heartbeat:IPaddr2 params foo="bar"!
-      primitive.parse_definition
-      expect(primitive.definition_string).to eq(<<'EOF'.chomp)
+      expect(primitive.definition).to eq(<<'EOF'.chomp)
 primitive foo ocf:heartbeat:IPaddr2 \
          params foo="bar"
 EOF
     end
   end
 
-  describe "#quoted_definition_string" do
+  describe "#quoted_definition" do
     it "should return the quoted definition string" do
       primitive = pacemaker_object_class.new("foo")
       primitive.definition = <<'EOF'.chomp
 primitive foo ocf:openstack:keystone \
          params bar="foo\"bar$b!az\q%ux" bar2="ba'z\'qux"
 EOF
-      primitive.parse_definition
-      expect(primitive.quoted_definition_string).to eq(<<'EOF'.chomp)
+      expect(primitive.quoted_definition).to eq(<<'EOF'.chomp)
 'primitive foo ocf:openstack:keystone \
          params bar="foo\"bar$b!az\q%ux" bar2="ba'\''z\\'\''qux"'
 EOF
@@ -105,7 +103,6 @@ EOF
     before(:each) do
       @parsed = pacemaker_object_class.new(fixture.name)
       @parsed.definition = fixture_definition
-      @parsed.parse_definition
     end
 
     it "should parse the agent" do

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource_spec.rb
@@ -33,27 +33,27 @@ describe Pacemaker::Resource do
     let(:fixture) { Chef::RSpec::Pacemaker::Config::KEYSTONE_PRIMITIVE.dup }
 
     it "should extract a params hash from config" do
-      expect(fixture.class.extract_hash(fixture.definition_string, "params")).to \
+      expect(fixture.class.extract_hash(fixture.definition, "params")).to \
         eq(Hash[fixture.params])
     end
 
     it "should extract an op start hash from config" do
-      expect(fixture.class.extract_hash(fixture.definition_string, "op start")).to \
+      expect(fixture.class.extract_hash(fixture.definition, "op start")).to \
         eq(Hash[fixture.op]["start"])
     end
 
     it "should extract an op monitor hash from config" do
-      expect(fixture.class.extract_hash(fixture.definition_string, "op monitor")).to \
+      expect(fixture.class.extract_hash(fixture.definition, "op monitor")).to \
         eq(Hash[fixture.op]["monitor"])
     end
 
     it "should extract an op monitor hash from config" do
-      expect(fixture.class.extract_hash(fixture.definition_string, "meta")).to \
+      expect(fixture.class.extract_hash(fixture.definition, "meta")).to \
         eq(Hash[fixture.meta])
     end
 
     it "should handle an empty meta section gracefully" do
-      no_meta = fixture.definition_string.gsub(/\bmeta .*\\$/, "meta \\")
+      no_meta = fixture.definition.gsub(/\bmeta .*\\$/, "meta \\")
       expect(fixture.class.extract_hash(no_meta, "meta")).to eq({})
     end
   end

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource_spec.rb
@@ -19,13 +19,13 @@ describe Pacemaker::Resource do
     it "should return true" do
       expect(@cmd).to receive(:stdout).at_least(:once) \
         .and_return("resource #{rsc.name} is running on: d52-54-00-e5-6b-a0")
-      expect(rsc.running?).to be(true)
+      expect(rsc.running?).to be_true
     end
 
     it "should return false" do
       expect(@cmd).to receive(:stdout).at_least(:once) \
         .and_return("resource #{rsc.name} is NOT running")
-      expect(rsc.running?).to be(false)
+      expect(rsc.running?).to be_false
     end
   end
 

--- a/chef/cookbooks/pacemaker/spec/providers/location_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/providers/location_spec.rb
@@ -3,69 +3,108 @@ require "spec_helper"
 require_relative "../helpers/provider"
 require_relative "../helpers/non_runnable_resource"
 require_relative "../fixtures/location_constraint"
+require_relative "../fixtures/location_rule_constraint"
 
 describe "Chef::Provider::PacemakerLocation" do
-  # for use inside examples:
-  let(:fixture) { Chef::RSpec::Pacemaker::Config::LOCATION_CONSTRAINT.dup }
-  # for use outside examples (e.g. when invoking shared_examples)
-  fixture = Chef::RSpec::Pacemaker::Config::LOCATION_CONSTRAINT.dup
-
   def lwrp_name
     "location"
   end
 
   include_context "a Pacemaker LWRP with artificially constructed resource"
 
-  before(:each) do
-    @resource.rsc fixture.rsc
-    @resource.score fixture.score
-    @resource.lnode fixture.lnode.dup
-  end
-
   def cib_object_class
     Pacemaker::Constraint::Location
   end
 
-  shared_examples "an updateable resource" do
-    include Chef::RSpec::Pacemaker::CIBObject
+  context "attribute-based" do
+    # for use inside examples:
+    let(:fixture) { Chef::RSpec::Pacemaker::Config::LOCATION_CONSTRAINT.dup }
+    # for use outside examples (e.g. when invoking shared_examples)
+    fixture = Chef::RSpec::Pacemaker::Config::LOCATION_CONSTRAINT.dup
 
-    it "should modify the constraint if it has a different resource" do
-      new_resource = "group2"
-      fixture.rsc = new_resource
-      expected_configure_cmd_args = [fixture.reconfigure_command]
-      test_modify(expected_configure_cmd_args) do
-        @resource.rsc new_resource
+    before(:each) do
+      @resource.rsc fixture.rsc
+      @resource.score fixture.score
+      @resource.lnode fixture.lnode.dup
+    end
+
+    shared_examples "an updateable resource" do
+      include Chef::RSpec::Pacemaker::CIBObject
+
+      it "should modify the constraint if it has a different resource" do
+        new_resource = "group2"
+        fixture.rsc = new_resource
+        expected_configure_cmd_args = [fixture.reconfigure_command]
+        test_modify(expected_configure_cmd_args) do
+          @resource.rsc new_resource
+        end
+      end
+
+      it "should modify the constraint if it has a different score" do
+        new_score = "100"
+        fixture.score = new_score
+        expected_configure_cmd_args = [fixture.reconfigure_command]
+        test_modify(expected_configure_cmd_args) do
+          @resource.score new_score
+        end
+      end
+
+      it "should modify the constraint if it has a different node" do
+        new_node = "node2"
+        fixture.lnode = new_node
+        expected_configure_cmd_args = [fixture.reconfigure_command]
+        test_modify(expected_configure_cmd_args) do
+          @resource.lnode new_node
+        end
       end
     end
 
-    it "should modify the constraint if it has a different score" do
-      new_score = "100"
-      fixture.score = new_score
-      expected_configure_cmd_args = [fixture.reconfigure_command]
-      test_modify(expected_configure_cmd_args) do
-        @resource.score new_score
+    describe ":create action" do
+      let(:action) { :create }
+      it_should_behave_like "an updateable resource"
+    end
+
+    describe ":update action" do
+      let(:action) { :update }
+      it_should_behave_like "an updateable resource"
+    end
+
+    it_should_behave_like "a non-runnable resource", fixture
+  end
+
+  context "arbitrary string" do
+    # for use inside examples:
+    let(:fixture) { Chef::RSpec::Pacemaker::Config::LOCATION_RULE_CONSTRAINT.dup }
+    # for use outside examples (e.g. when invoking shared_examples)
+    fixture = Chef::RSpec::Pacemaker::Config::LOCATION_RULE_CONSTRAINT.dup
+
+    before(:each) do
+      @resource.definition fixture.definition
+    end
+
+    shared_examples "an updateable resource" do
+      include Chef::RSpec::Pacemaker::CIBObject
+
+      it "should modify the constraint if it has a different definition" do
+        new_definition = fixture.definition + " foo"
+        fixture.definition = new_definition
+        expected_configure_cmd_args = [fixture.reconfigure_command]
+        test_modify(expected_configure_cmd_args) do
+          @resource.definition new_definition
+        end
       end
     end
 
-    it "should modify the constraint if it has a different node" do
-      new_node = "node2"
-      fixture.lnode = new_node
-      expected_configure_cmd_args = [fixture.reconfigure_command]
-      test_modify(expected_configure_cmd_args) do
-        @resource.lnode new_node
-      end
+    describe ":create action" do
+      let(:action) { :create }
+      it_should_behave_like "an updateable resource"
     end
-  end
 
-  describe ":create action" do
-    let(:action) { :create }
-    it_should_behave_like "an updateable resource"
-  end
+    describe ":update action" do
+      let(:action) { :update }
+      it_should_behave_like "an updateable resource"
+    end
 
-  describe ":update action" do
-    let(:action) { :update }
-    it_should_behave_like "an updateable resource"
+    it_should_behave_like "a non-runnable resource", fixture
   end
-
-  it_should_behave_like "a non-runnable resource", fixture
 end

--- a/chef/cookbooks/pacemaker/spec/providers/location_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/providers/location_spec.rb
@@ -19,7 +19,7 @@ describe "Chef::Provider::PacemakerLocation" do
   before(:each) do
     @resource.rsc fixture.rsc
     @resource.score fixture.score
-    @resource.node fixture.node.dup
+    @resource.lnode fixture.lnode.dup
   end
 
   def cib_object_class
@@ -49,10 +49,10 @@ describe "Chef::Provider::PacemakerLocation" do
 
     it "should modify the constraint if it has a different node" do
       new_node = "node2"
-      fixture.node = new_node
+      fixture.lnode = new_node
       expected_configure_cmd_args = [fixture.reconfigure_command]
       test_modify(expected_configure_cmd_args) do
-        @resource.node new_node
+        @resource.lnode new_node
       end
     end
   end

--- a/chef/cookbooks/pacemaker/spec/providers/primitive_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/providers/primitive_spec.rb
@@ -171,7 +171,7 @@ EOF
 
     it "should barf if the primitive is already defined with the wrong agent" do
       existing_agent = "ocf:openstack:something-else"
-      definition = fixture.definition_string.sub(fixture.agent, existing_agent)
+      definition = fixture.definition.sub(fixture.agent, existing_agent)
       mock_existing_cib_object(fixture.name, definition)
 
       expected_error = \


### PR DESCRIPTION
Until now, CIB objects were only instantiated by supplying individual fine-grained attributes, e.g. in the case of `location` constraints, the attributes are `name`, `rsc`, `score`, and `node`.

However CIB objects can actually have more complicated structures, and we need to support some of them, such as rule-based constraints like:

    location rulelocation1 primitive1 resource-discovery=exclusive \
        rule 0: OpenStack-role eq controller

In fact `crmsh` even supports `location` constraints with far more complicated syntax than this.  So rather than attempting to reimplement the entire `crmsh` parser, we just add support for objects which are defined by arbitrary definition strings.  The only bit we actually need to parse is the first two words, i.e. the object's type and name respectively.

To maintain backwards compatibility with callers which still want to construct objects in the fine-grained manner, we add an internal `@authority` instance variable which determines whether the source of authority for the object's definition is the fine-grained attributes or the arbitrary unparsed string.  When a subclass's `#parse_definition` method succeeds in parsing the definition string into fine-grained attribute values, it must invoke a `#attrs_authoritative` method newly defined in the base class which sets `@authority` to `:attributes`. Otherwise the definition will be retrieved directly from the raw definition string.  This new mechanism replaces `#definition_string`, which was a semantic duplication of `#definition`.

We also remove `#load_definition`, which was a hack only used by tests, and instead do tests using the more real-world `.from_name` API.