### PR TITLE
crowbar-pacemaker: Add num_corosync_nodes helper

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/helpers.rb
@@ -33,6 +33,15 @@ module CrowbarPacemakerHelper
     end
   end
 
+  # Returns the number of corosync (or non-remote) nodes in the cluster.
+  def self.num_corosync_nodes(node)
+    if cluster_enabled?(node)
+      node[:pacemaker][:elements]["pacemaker-cluster-member"].length
+    else
+      0
+    end
+  end
+
   # Returns the name of the cluster containing the given node, or nil
   # if the node is not in a cluster.  The name is determined by the
   # name of the pacemaker proposal corresponding to that cluster


### PR DESCRIPTION
This can be used when creating clones to set the clone-max metadata.