### PR TITLE
crowbar-pacemaker: Add ability to set custom attributes on nodes

### DIFF
--- a/chef/cookbooks/corosync/recipes/authkey.rb
+++ b/chef/cookbooks/corosync/recipes/authkey.rb
@@ -25,7 +25,7 @@ if Chef::Config[:solo]
 end
 
 cluster_name = node[:corosync][:cluster_name]
-unless cluster_name and ! cluster_name.empty?
+unless cluster_name && !cluster_name.empty?
   Chef::Application.fatal! "Couldn't figure out corosync cluster name"
   return
 end

--- a/chef/cookbooks/corosync/recipes/authkey.rb
+++ b/chef/cookbooks/corosync/recipes/authkey.rb
@@ -34,6 +34,7 @@ end
 query  = "chef_environment:#{node.chef_environment}"
 query += " AND corosync_cluster_name:#{cluster_name}"
 
+# FIXME: move this Crowbar-specific code into the crowbar-pacemaker cookbook
 is_crowbar = !(node[:crowbar].nil?)
 authkey_node = nil
 

--- a/chef/cookbooks/crowbar-pacemaker/attributes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/attributes/default.rb
@@ -31,3 +31,9 @@ else
 end
 default[:pacemaker][:haproxy][:op][:monitor][:interval] = "10s"
 default[:pacemaker][:haproxy][:clusters] = {}
+
+default[:pacemaker][:remote][:agent] = "ocf:pacemaker:remote"
+default[:pacemaker][:remote][:op][:monitor][:interval] = "20s"
+default[:pacemaker][:remote][:op][:start][:timeout] = "60s"
+default[:pacemaker][:remote][:op][:stop][:timeout] = "60s"
+default[:pacemaker][:remote][:params][:reconnect_interval] = "60s"

--- a/chef/cookbooks/crowbar-pacemaker/attributes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/attributes/default.rb
@@ -19,6 +19,8 @@
 
 # We're in the pacemaker barclamp, so we're using the pacemaker namespace
 
+default[:pacemaker][:attributes] = {}
+
 default[:pacemaker][:platform][:resource_packages][:openstack] = %w(openstack-resource-agents)
 
 if node[:platform] == "suse" && node[:platform_version].to_f < 12.0

--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -44,6 +44,9 @@ end.run_action(:guess)
 
 include_recipe "pacemaker::default"
 
+# Set up authkey for pacemaker remotes (different to corosync authkey)
+include_recipe "crowbar-pacemaker::pacemaker_authkey"
+
 # This is not done in the compile phase, because saving the authkey attribute
 # is done in a ruby_block
 crowbar_pacemaker_sync_mark "create-pacemaker_setup" do

--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -69,6 +69,15 @@ if node[:pacemaker][:drbd][:enabled]
   include_recipe "crowbar-pacemaker::drbd"
 end
 
+node[:pacemaker][:attributes].each do |attr, value|
+  execute "set pacemaker attribute \"#{attr}\" to \"#{value}\"" do
+    command "crm node attribute #{node[:hostname]} set \"#{attr}\" \"#{value}\""
+    # The cluster only does a transition if the attribute value changes,
+    # so checking the value before setting would only slow things down
+    # for no benefit.
+  end
+end
+
 include_recipe "crowbar-pacemaker::haproxy"
 include_recipe "crowbar-pacemaker::maintenance-mode"
 include_recipe "crowbar-pacemaker::mutual_ssh"

--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -22,25 +22,7 @@
 # server side. This only happens the very first time (which is when we don't
 # even have an auth key); on next runs, we know we're good.
 if node[:corosync][:authkey].nil?
-  require "timeout"
-
-  begin
-    Timeout.timeout(20) do
-      Chef::Log.info("Waiting for cluster founder to be indexed...")
-      while true
-        begin
-          founder = CrowbarPacemakerHelper.cluster_founder(node)
-          Chef::Log.info("Cluster founder found: #{founder.name}")
-          break
-        rescue
-          Chef::Log.info("No cluster founder found yet, waiting...")
-          sleep(2)
-        end
-      end # while true
-    end # Timeout
-  rescue Timeout::Error
-    Chef::Log.warn("Cluster founder not found!")
-  end
+  include_recipe "crowbar-pacemaker::wait_for_founder"
 end
 
 node[:corosync][:cluster_name] = CrowbarPacemakerHelper.cluster_name(node)

--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -70,7 +70,5 @@ if node[:pacemaker][:drbd][:enabled]
 end
 
 include_recipe "crowbar-pacemaker::haproxy"
-
 include_recipe "crowbar-pacemaker::maintenance-mode"
-
 include_recipe "crowbar-pacemaker::mutual_ssh"

--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -45,17 +45,7 @@ end
 
 node[:corosync][:cluster_name] = CrowbarPacemakerHelper.cluster_name(node)
 
-# Enforce no-quorum-policy based on the number of members in the clusters
-# We know that for 2 members (or 1, where it doesn't matter), the setting
-# should be "ignore". If we have more members, then we use the value set in the
-# barclamp.
-# For details on the different policies, see
-# https://www.suse.com/documentation/sle_ha/book_sleha/data/sec_ha_configuration_basics_global.html
-cluster_members_nb = CrowbarPacemakerHelper.cluster_nodes(node).length
-if cluster_members_nb <= 2
-  node.default[:pacemaker][:crm][:no_quorum_policy] = "ignore"
-end
-
+include_recipe "crowbar-pacemaker::quorum_policy"
 include_recipe "crowbar-pacemaker::stonith"
 
 # We let the founder go first, so it can generate the authkey and some other

--- a/chef/cookbooks/crowbar-pacemaker/recipes/pacemaker_authkey.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/pacemaker_authkey.rb
@@ -1,0 +1,65 @@
+#
+# Cookbook Name:: crowbar-pacemaker
+# Recipe:: pacemaker_authkey
+#
+# Copyright 2015, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "base64"
+
+if Chef::Config[:solo]
+  Chef::Application.fatal! "This recipe uses search. Chef Solo does not support search."
+  return
+end
+
+# FIXME: deduplicate code with corosync::authkey recipe
+
+cluster_name = node[:corosync][:cluster_name]
+unless cluster_name && !cluster_name.empty?
+  Chef::Application.fatal! "Couldn't figure out corosync cluster name"
+  return
+end
+
+# Find pre-existing authkey on other node(s)
+query  = "chef_environment:#{node.chef_environment}"
+query += " AND corosync_cluster_name:#{cluster_name}"
+
+authkey_node = nil
+
+if node[:pacemaker][:founder]
+  if node[:pacemaker][:authkey].nil?
+    include_recipe "pacemaker::authkey_generator"
+  else
+    # make sure the authkey stays written
+    include_recipe "pacemaker::authkey_writer"
+  end
+else
+  query +=
+    " AND pacemaker_founder:true " \
+    " AND pacemaker_config_environment:#{node[:pacemaker][:config][:environment]}"
+  founder_nodes = search(:node, query)
+  raise "No founder node found!" if founder_nodes.length == 0
+  raise "Multiple founder nodes found!" if founder_nodes.length > 1
+  authkey_node = founder_nodes[0]
+end
+
+unless authkey_node.nil?
+  log("Using pacemaker authkey from node: #{authkey_node.name}")
+  authkey = authkey_node[:pacemaker][:authkey]
+
+  node.set[:pacemaker][:authkey] = authkey
+  node.save
+  include_recipe "pacemaker::authkey_writer"
+end

--- a/chef/cookbooks/crowbar-pacemaker/recipes/pacemaker_authkey.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/pacemaker_authkey.rb
@@ -17,6 +17,13 @@
 # limitations under the License.
 #
 
+# This recipe is intended for use on *all* cluster nodes, i.e. both
+# corosync and remote nodes.  Only the founder generates an authkey
+# for communication with remote nodes, and all the others copy it;
+# thefore it must be run on the corosync nodes first.  Crowbar
+# achieves this by first running it via the pacemaker-cluster-member
+# role, and then later by the pacemaker-remote role.
+
 require "base64"
 
 if Chef::Config[:solo]

--- a/chef/cookbooks/crowbar-pacemaker/recipes/quorum_policy.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/quorum_policy.rb
@@ -1,0 +1,29 @@
+#
+# Cookbook Name:: crowbar-pacemaker
+# Recipe:: quorum_policy
+#
+# Copyright 2015, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Enforce no-quorum-policy based on the number of members in the clusters
+# We know that for 2 members (or 1, where it doesn't matter), the setting
+# should be "ignore". If we have more members, then we use the value set in the
+# barclamp.
+# For details on the different policies, see
+# https://www.suse.com/documentation/sle_ha/book_sleha/data/sec_ha_configuration_basics_global.html
+cluster_members_nb = CrowbarPacemakerHelper.cluster_nodes(node).length
+if cluster_members_nb <= 2
+  node.default[:pacemaker][:crm][:no_quorum_policy] = "ignore"
+end

--- a/chef/cookbooks/crowbar-pacemaker/recipes/remote.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/remote.rb
@@ -1,0 +1,40 @@
+#
+# Author:: Adam Spiers
+# Cookbook Name:: crowbar-pacemaker
+# Recipe:: remote
+#
+# Copyright 2015, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# The parent recipe to be run on all remote nodes.
+
+# Figure out which cluster we're tied to, so that we can find the founder
+# and hence the authkey.
+node[:corosync][:cluster_name] = CrowbarPacemakerHelper.cluster_name(node)
+
+include_recipe "crowbar-pacemaker::pacemaker_authkey"
+include_recipe "pacemaker::remote"
+
+# if we ever want to not have a hard dependency on openstack here, we can have
+# Crowbar set a node[:pacemaker][:resource_agents] attribute based on available
+# barclamps, and do:
+# node[:pacemaker][:resource_agents].each do |resource_agent|
+#   node[:pacemaker][:platform][:resource_packages][resource_agent].each do |pkg|
+#     package pkg
+#   end
+# end
+node[:pacemaker][:platform][:resource_packages][:openstack].each do |pkg|
+  package pkg
+end

--- a/chef/cookbooks/crowbar-pacemaker/recipes/remote_delegator.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/remote_delegator.rb
@@ -1,0 +1,44 @@
+#
+# Author:: Adam Spiers
+# Cookbook Name:: crowbar-pacemaker
+# Recipe:: remote_delegator
+#
+# Copyright 2015, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This recipe should be run on the corosync nodes in order to set up
+# ocf:pacemaker:remote primitives so that they can control the remote
+# nodes via the pacemaker_remote proxy service running on the remote
+# nodes.
+
+return unless CrowbarPacemakerHelper.is_cluster_founder?(node)
+
+query  = "chef_environment:#{node.chef_environment}"
+query += " AND roles:pacemaker-remote"
+query += " AND corosync_cluster_name:#{node[:corosync][:cluster_name]}"
+query += " AND pacemaker_config_environment:#{node[:pacemaker][:config][:environment]}"
+
+remotes = search(:node, query)
+remotes.each do |remote|
+  params_hash = remote[:pacemaker][:remote][:params].to_hash
+  params_hash["server"] = remote[:fqdn]
+
+  pacemaker_primitive "remote-#{remote[:hostname]}" do
+    agent remote[:pacemaker][:remote][:agent]
+    op remote[:pacemaker][:remote][:op].to_hash
+    params params_hash
+    action [:create, :start]
+  end
+end

--- a/chef/cookbooks/crowbar-pacemaker/recipes/remote_delegator.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/remote_delegator.rb
@@ -42,4 +42,14 @@ remotes.each do |remote|
     action [:create, :start]
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
+
+  remote[:pacemaker][:attributes].each do |attr, value|
+    execute "set pacemaker attribute \"#{attr}\" to \"#{value}\" on remote #{remote[:hostname]}" do
+      command "crm node attribute #{remote[:hostname]} set \"#{attr}\" \"#{value}\""
+      # The cluster only does a transition if the attribute value changes,
+      # so checking the value before setting would only slow things down
+      # for no benefit.
+      only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+    end
+  end
 end

--- a/chef/cookbooks/crowbar-pacemaker/recipes/remote_delegator.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/remote_delegator.rb
@@ -40,5 +40,6 @@ remotes.each do |remote|
     op remote[:pacemaker][:remote][:op].to_hash
     params params_hash
     action [:create, :start]
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
 end

--- a/chef/cookbooks/crowbar-pacemaker/recipes/wait_for_founder.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/wait_for_founder.rb
@@ -26,7 +26,7 @@ require "timeout"
 begin
   Timeout.timeout(20) do
     Chef::Log.info("Waiting for cluster founder to be indexed...")
-    while true
+    loop do
       begin
         founder = CrowbarPacemakerHelper.cluster_founder(node)
         Chef::Log.info("Cluster founder found: #{founder.name}")

--- a/chef/cookbooks/crowbar-pacemaker/recipes/wait_for_founder.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/wait_for_founder.rb
@@ -1,0 +1,42 @@
+#
+# Cookbook Name:: crowbar-pacemaker
+# Recipe:: wait_for_founder
+#
+# Copyright 2014, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Simple helper to allow us to correctly synchronize cluster
+# initialization: we need the founder to initialize and generate the
+# authkey before the other nodes do anything.
+
+require "timeout"
+
+begin
+  Timeout.timeout(20) do
+    Chef::Log.info("Waiting for cluster founder to be indexed...")
+    while true
+      begin
+        founder = CrowbarPacemakerHelper.cluster_founder(node)
+        Chef::Log.info("Cluster founder found: #{founder.name}")
+        break
+      rescue
+        Chef::Log.info("No cluster founder found yet, waiting...")
+        sleep(2)
+      end
+    end # while true
+  end # Timeout
+rescue Timeout::Error
+  Chef::Log.warn("Cluster founder not found!")
+end

--- a/chef/cookbooks/pacemaker/attributes/default.rb
+++ b/chef/cookbooks/pacemaker/attributes/default.rb
@@ -15,7 +15,10 @@
 
 case node[:platform_family]
 when "suse"
-  default[:pacemaker][:platform][:packages] = %w(pacemaker crmsh)
+  default[:pacemaker][:platform][:packages] =
+    %w(pacemaker crmsh fence-agents)
+  default[:pacemaker][:platform][:remote_packages] =
+    %w(pacemaker-remote fence-agents)
 else
 
   #

--- a/chef/cookbooks/pacemaker/attributes/default.rb
+++ b/chef/cookbooks/pacemaker/attributes/default.rb
@@ -81,3 +81,6 @@ default[:pacemaker][:notifications][:smtp][:to] = ""
 default[:pacemaker][:notifications][:smtp][:from] = ""
 default[:pacemaker][:notifications][:smtp][:server] = ""
 default[:pacemaker][:notifications][:smtp][:prefix] = ""
+
+default[:pacemaker][:authkey_file] = "/etc/pacemaker/authkey"
+default[:pacemaker][:authkey_file_owner] = "hacluster" # same as default[:corosync][:user]

--- a/chef/cookbooks/pacemaker/recipes/authkey_writer.rb
+++ b/chef/cookbooks/pacemaker/recipes/authkey_writer.rb
@@ -1,0 +1,39 @@
+#
+# Cookbook Name:: pacemaker
+# Recipe:: authkey_writer
+#
+# Copyright 2015, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+authkey      = node[:pacemaker][:authkey]
+authkey_file = node[:pacemaker][:authkey_file]
+
+directory File.dirname(authkey_file) do
+  owner "root"
+  group "root"
+  mode "0755"
+  action :create
+end
+
+# decode so we can write out to file below
+pacemaker_authkey = Base64.decode64(authkey)
+
+file authkey_file do
+  content pacemaker_authkey
+  owner node[:pacemaker][:authkey_file_owner]
+  group "root"
+  mode "0400"
+  action :create
+end

--- a/chef/cookbooks/pacemaker/recipes/remote.rb
+++ b/chef/cookbooks/pacemaker/recipes/remote.rb
@@ -1,0 +1,66 @@
+#
+# Author:: Adam Spiers
+# Cookbook Name:: pacemaker
+# Recipe:: remote
+#
+# Copyright 2015, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Install and start the pacemaker_remote service.  This recipe makes
+# two assumptions:
+#
+#   - The Pacemaker authkey for communication between corosync nodes
+#     and remotes is already set up on all nodes.  The
+#     ::authkey_generator and ::authkey_writer recipes will help with
+#     this, but it will require some orchestration in order to ensure
+#     that the authkey is only generated on one node and then copied
+#     to the others without any race conditions.  This is beyond Chef's
+#     abilities, so the responsibility is left to the caller.
+#
+#   - The ocf:pacemaker:remote primitives must not be configured until
+#     after this recipe has run and started the pacemaker_remoted
+#     services, otherwise the primitives will cause errors.
+
+if node[:pacemaker][:platform][:remote_packages].nil?
+  Chef::Application.fatal! "FIXME: #{node.platform} platform not supported yet"
+end
+
+node[:pacemaker][:platform][:remote_packages].each do |pkg|
+  package pkg
+end
+
+service "pacemaker_remote" do
+  action [:disable, :start]
+end
+
+# Start-up is asynchronous, so make sure the remote is reachable
+# before other recipes add the ocf:pacemaker:remote primitives which
+# will cause corosync nodes to attempt to contact it.
+ruby_block "wait for pacemaker_remote service to be reachable" do
+  block do
+    require "timeout"
+    Timeout.timeout(60) do
+      # Later we might introduce a Chef attribute for the port number,
+      # but this would require building a template for
+      # /etc/sysconfig/pacemaker on remote nodes, so it's not worth
+      # the effort until we really need it.
+      cmd = "netcat -t localhost 3121 </dev/null"
+      until ::Kernel.system(cmd)
+        Chef::Log.debug("pacemaker_remote not reachable yet")
+        sleep(5)
+      end
+    end
+  end # block
+end # ruby_block

--- a/chef/data_bags/crowbar/migrate/pacemaker/032_add_pacemaker_remote.rb
+++ b/chef/data_bags/crowbar/migrate/pacemaker/032_add_pacemaker_remote.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  d["element_states"] = td["element_states"]
+  d["element_order"] = td["element_order"]
+  d["element_run_list_order"] = td["element_run_list_order"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  d["element_states"] = td["element_states"]
+  d["element_order"] = td["element_order"]
+  d["element_run_list_order"] = td["element_run_list_order"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-pacemaker.json
+++ b/chef/data_bags/crowbar/template-pacemaker.json
@@ -55,12 +55,16 @@
       "crowbar-applied": false,
       "schema-revision": 32,
       "element_states": {
-        "pacemaker-cluster-member" : [ "readying", "ready", "applying" ],
-        "hawk-server"              : [ "readying", "ready", "applying" ]
+        "pacemaker-cluster-member"    : [ "readying", "ready", "applying" ],
+        "hawk-server"                 : [ "readying", "ready", "applying" ],
+        "pacemaker-remote"            : [ "readying", "ready", "applying" ],
+        "pacemaker-remote-delegator"  : [ "readying", "ready", "applying" ]
       },
       "elements": {},
       "element_order": [
-        [ "pacemaker-cluster-member", "hawk-server" ]
+        [ "pacemaker-cluster-member", "hawk-server" ],
+        [ "pacemaker-remote" ],
+        [ "pacemaker-remote-delegator" ]
       ],
       "config": {
         "environment": "pacemaker-base-config",

--- a/chef/data_bags/crowbar/template-pacemaker.json
+++ b/chef/data_bags/crowbar/template-pacemaker.json
@@ -53,7 +53,7 @@
     "pacemaker": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 31,
+      "schema-revision": 32,
       "element_states": {
         "pacemaker-cluster-member" : [ "readying", "ready", "applying" ],
         "hawk-server"              : [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-pacemaker.schema
+++ b/chef/data_bags/crowbar/template-pacemaker.schema
@@ -176,6 +176,16 @@
                 "sequence": [ { "type": "str" } ]
               } ]
             },
+            "element_run_list_order": {
+              "type": "map",
+              "required": false,
+              "mapping": {
+                = : {
+                  "type": "int",
+                  "required": true
+                }
+              }
+            },
             "config": {
               "type": "map",
               "required": true,

--- a/chef/roles/hawk-server.rb
+++ b/chef/roles/hawk-server.rb
@@ -3,5 +3,5 @@ description "Hawk web server"
 run_list(
          "recipe[hawk::server]"
 )
-default_attributes()
-override_attributes()
+default_attributes
+override_attributes

--- a/chef/roles/pacemaker-cluster-member.rb
+++ b/chef/roles/pacemaker-cluster-member.rb
@@ -1,7 +1,7 @@
 name "pacemaker-cluster-member"
 description "Pacemaker cluster member"
 run_list(
-         "recipe[crowbar-pacemaker::default]"
+  "recipe[crowbar-pacemaker::default]"
 )
-default_attributes()
-override_attributes()
+default_attributes
+override_attributes

--- a/chef/roles/pacemaker-remote-delegator.rb
+++ b/chef/roles/pacemaker-remote-delegator.rb
@@ -3,5 +3,5 @@ description "Pacemaker remote node delegator"
 run_list(
   "recipe[crowbar-pacemaker::remote_delegator]"
 )
-default_attributes()
-override_attributes()
+default_attributes
+override_attributes

--- a/chef/roles/pacemaker-remote-delegator.rb
+++ b/chef/roles/pacemaker-remote-delegator.rb
@@ -1,0 +1,7 @@
+name "pacemaker-remote-delegator"
+description "Pacemaker remote node delegator"
+run_list(
+  "recipe[crowbar-pacemaker::remote_delegator]"
+)
+default_attributes()
+override_attributes()

--- a/chef/roles/pacemaker-remote.rb
+++ b/chef/roles/pacemaker-remote.rb
@@ -3,5 +3,5 @@ description "Pacemaker remote cluster member"
 run_list(
   "recipe[crowbar-pacemaker::remote]"
 )
-default_attributes()
-override_attributes()
+default_attributes
+override_attributes

--- a/chef/roles/pacemaker-remote.rb
+++ b/chef/roles/pacemaker-remote.rb
@@ -1,0 +1,7 @@
+name "pacemaker-remote"
+description "Pacemaker remote cluster member"
+run_list(
+  "recipe[crowbar-pacemaker::remote]"
+)
+default_attributes()
+override_attributes()

--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -43,6 +43,22 @@ class PacemakerService < ServiceObject
             "suse" => "/.*/",
             "opensuse" => "/.*/"
           }
+        },
+        "pacemaker-remote" => {
+          "unique" => false,
+          "count" => -1,
+          "platform" => {
+            "suse" => "/.*/",
+            "opensuse" => "/.*/"
+          }
+        },
+        "pacemaker-remote-delegator" => {
+          "unique" => false,
+          "count" => -1,
+          "platform" => {
+            "suse" => "/.*/",
+            "opensuse" => "/.*/"
+          }
         }
       }
     end

--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -635,15 +635,17 @@ class PacemakerService < ServiceObject
     proposals_raw.each do |p|
       next if p["id"] == proposal["id"]
 
-      (p["deployment"][@bc_name]["elements"]["pacemaker-cluster-member"] || []).each do |other_member|
-        if members.include?(other_member)
-          p_name = p["id"].gsub("#{@bc_name}-", "")
-          validation_error I18n.t(
-            "barclamp.#{bc_name}.validation.pacemaker_proposal",
-            other_members: other_members,
-            p_name: p_name
-          )
-        end
+      other_members = p["deployment"][@bc_name]["elements"]["pacemaker-cluster-member"] || []
+      other_remotes = p["deployment"][@bc_name]["elements"]["pacemaker-remote"] || []
+      (other_members + other_remotes).each do |other_member|
+        next unless members.include?(other_member) || remotes.include?(other_member)
+
+        p_name = p["id"].gsub("#{@bc_name}-", "")
+        validation_error I18n.t(
+          "barclamp.#{bc_name}.validation.pacemaker_proposal",
+          other_member: other_member,
+          p_name: p_name
+        )
       end
     end
 

--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -525,19 +525,43 @@ class PacemakerService < ServiceObject
 
     elements = proposal["deployment"]["pacemaker"]["elements"]
     members = elements["pacemaker-cluster-member"] || []
+    remotes = elements["pacemaker-remote"] || []
 
     if elements.key?("hawk-server")
       elements["hawk-server"].each do |n|
         @logger.debug("checking #{n}")
-        unless members.include? n
-          node = NodeObject.find_node_by_name(n)
-          name = node.name
-          name = "#{node.alias} (#{name})" if node.alias
-          validation_error I18n.t(
-            "barclamp.#{bc_name}.validation.hawk_server",
-            name: name
-          )
-        end
+        next if members.include? n
+
+        node = NodeObject.find_node_by_name(n)
+        name = node.name
+        name = "#{node.alias} (#{name})" if node.alias
+        validation_error I18n.t(
+          "barclamp.#{bc_name}.validation.hawk_server",
+          name: name
+        )
+      end
+    end
+
+    unless remotes.empty?
+      if elements["pacemaker-remote-delegator"].empty?
+        validation_error I18n.t(
+          "barclamp.#{bc_name}.validation.pacemaker_remote_no_delegator"
+        )
+      end
+    end
+
+    if elements.key?("pacemaker-remote-delegator")
+      elements["pacemaker-remote-delegator"].each do |n|
+        @logger.debug("checking #{n}")
+        next if members.include? n
+
+        node = NodeObject.find_node_by_name(n)
+        name = node.name
+        name = "#{node.alias} (#{name})" if node.alias
+        validation_error I18n.t(
+          "barclamp.#{bc_name}.validation.pacemaker_remote_delegator",
+          name: name
+        )
       end
     end
 

--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -45,7 +45,7 @@ class PacemakerService < ServiceObject
           }
         },
         "pacemaker-remote" => {
-          "unique" => false,
+          "unique" => true,
           "count" => -1,
           "platform" => {
             "suse" => "/.*/",

--- a/crowbar_framework/config/locales/pacemaker/en.yml
+++ b/crowbar_framework/config/locales/pacemaker/en.yml
@@ -115,6 +115,8 @@ en:
         libvirt: 'Node  %{member} does not seem to be running in libvirt.'
         stonith_mode: 'Unknown STONITH mode: %{stonith_mode}.'
         hawk_server: 'Node %{name} has the hawk-server role but not the pacemaker-cluster-member role.'
+        pacemaker_remote_no_delegator: 'At least one cluster member must have the pacemaker-remote-delegator role when there are nodes with the pacemaker-remote role.'
+        pacemaker_remote_delegator: 'Node %{name} has the pacemaker-remote-delegator role but not the pacemaker-cluster-member role.'
         smtp_server: 'Invalid SMTP server for mail notifications.'
         sender_address: 'Invalid sender address for mail notifications.'
         recipient_address: 'Invalid recipient address for mail notifications.'


### PR DESCRIPTION
This will be useful to set the OpenStack-role attribute.

Note that this contains https://github.com/crowbar/crowbar-ha/pull/55 -- only the last commit is different here.