### PR TITLE
crowbar-pacemaker: Add ability to set custom attributes on nodes

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/attributes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/attributes/default.rb
@@ -19,6 +19,8 @@
 
 # We're in the pacemaker barclamp, so we're using the pacemaker namespace
 
+default[:pacemaker][:attributes] = {}
+
 default[:pacemaker][:platform][:resource_packages][:openstack] = %w(openstack-resource-agents)
 
 if node[:platform] == "suse" && node[:platform_version].to_f < 12.0

--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -94,6 +94,15 @@ if node[:pacemaker][:drbd][:enabled]
   include_recipe "crowbar-pacemaker::drbd"
 end
 
+node[:pacemaker][:attributes].each do |attr, value|
+  execute "set pacemaker attribute \"#{attr}\" to \"#{value}\"" do
+    command "crm node attribute #{node[:hostname]} set \"#{attr}\" \"#{value}\""
+    # The cluster only does a transition if the attribute value changes,
+    # so checking the value before setting would only slow things down
+    # for no benefit.
+  end
+end
+
 include_recipe "crowbar-pacemaker::haproxy"
 
 include_recipe "crowbar-pacemaker::maintenance-mode"


### PR DESCRIPTION
This will be useful to set the OpenStack-role attribute.

This is the bit from https://github.com/crowbar/crowbar-ha/pull/58 that can be merged right now.