### PR TITLE
pacemaker: Use crm_resource instead of crm when checking for existence

### DIFF
--- a/chef/cookbooks/pacemaker/libraries/pacemaker/resource.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/resource.rb
@@ -11,6 +11,21 @@ module Pacemaker
       "#{type} resource"
     end
 
+    def exists?(name)
+      # Directly use crm_resource, as it's faster than crm. This cannot be done
+      # for all CIBObjects as this works only for resources, and not for
+      # constraints :/
+      cmd = Mixlib::ShellOut.new("crm_resource --resource #{name} --query-xml-raw")
+      cmd.environment["HOME"] = ENV.fetch("HOME", "/root")
+      cmd.run_command
+      begin
+        cmd.error!
+        true
+      rescue
+        false
+      end
+    end
+
     def running?
       cmd = shell_out! "crm", "resource", "status", name
       Chef::Log.info cmd.stdout


### PR DESCRIPTION
crm is relatively slow (especially in the CI), while crm_resource is
fast (10x faster). This can have quite an impact on the duration of
chef-client for a cluster with many resources.
