### PR TITLE
crowbar-pacemaker: Add location constraint for haproxy & apache

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/metadata.rb
+++ b/chef/cookbooks/crowbar-pacemaker/metadata.rb
@@ -10,3 +10,5 @@ depends "drbd"
 depends "haproxy"
 depends "lvm"
 depends "pacemaker"
+
+recommends "crowbar-openstack"

--- a/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb
@@ -66,6 +66,11 @@ pacemaker_clone clone_name do
 end
 transaction_objects << "pacemaker_clone[#{clone_name}]"
 
+if node[:pacemaker][:apache2][:for_openstack]
+  location_name = openstack_pacemaker_controller_only_location_for clone_name
+  transaction_objects << "pacemaker_location[#{location_name}]"
+end
+
 pacemaker_transaction "apache service" do
   cib_objects transaction_objects
   # note that this will also automatically start the resources

--- a/chef/cookbooks/crowbar-pacemaker/recipes/haproxy.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/haproxy.rb
@@ -91,6 +91,11 @@ if node[:pacemaker][:haproxy][:clusters].key?(cluster_name) && node[:pacemaker][
   end
   transaction_objects << "pacemaker_group[#{group_name}]"
 
+  if node[:pacemaker][:haproxy][:for_openstack]
+    location_name = openstack_pacemaker_controller_only_location_for group_name
+    transaction_objects << "pacemaker_location[#{location_name}]"
+  end
+
   pacemaker_transaction "haproxy service" do
     cib_objects transaction_objects
     # note that this will also automatically start the resources


### PR DESCRIPTION
~~**Note:** only last commit is of interest here for the review, the rest is from https://github.com/crowbar/crowbar-ha/pull/51 (but is required for this last commit).~~

**Note:** this goes hand in hand with https://github.com/crowbar/crowbar-openstack/pull/215

**Note:** this depends on ~~https://github.com/crowbar/crowbar-ha/pull/56~~

Because the pacemaker resources for haproxy and apache are created here
in crowbar-pacemaker, we, in theory, shouldn't assume there that these
two services will be used for OpenStack and so we can't always just add
the location constraint to tell pacemaker to only run these on
controller nodes.

However, we do need the constraints when it's OpenStack. So crowbar will
add a flag to tell us to add these constraints, and when it's there, we
do what we're asked to do.