### PR TITLE
pacemaker: Keep compatibility with older version of ruby

### DIFF
--- a/chef/cookbooks/pacemaker/libraries/pacemaker/transaction.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/transaction.rb
@@ -6,9 +6,9 @@ module Pacemaker
   class Transaction
     attr_reader :name, :cib_objects
 
-    def initialize(name:, cib_objects:)
-      @name = name
-      @cib_objects = cib_objects
+    def initialize(options = {})
+      @name = options.fetch(:name, "")
+      @cib_objects = options.fetch(:cib_objects, [])
     end
 
     def definition


### PR DESCRIPTION
On Windows (where the pacemaker cookbook is loaded due to dependencies),
we don't seem to have a stack that supports keyword arguments. So don't
use this.