### PR TITLE
crowbar-pacemaker: Set clone-max metadata for clone resources

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb
@@ -61,6 +61,7 @@ transaction_objects << "pacemaker_primitive[#{service_name}]"
 clone_name = "cl-#{service_name}"
 pacemaker_clone clone_name do
   rsc service_name
+  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end


### PR DESCRIPTION
This is useful to have hawk / crm not be confused by remote nodes which
should not use the clones.