### PR TITLE
pacemaker: Avoid calling crm for redefining resources while there's no diff

### DIFF
--- a/chef/cookbooks/pacemaker/libraries/chef/mixin/pacemaker/standard_cib_object.rb
+++ b/chef/cookbooks/pacemaker/libraries/chef/mixin/pacemaker/standard_cib_object.rb
@@ -135,10 +135,14 @@ class Chef
           desired.meta.delete("target-role")
         end
 
-        if desired.definition != @current_cib_object.definition
+        # compare one-line definitions
+        current_definition = @current_cib_object.definition.strip.gsub(/\s*\\\n\s*/, " ")
+        desired_definition = desired.definition.strip.gsub(/\s*\\\n\s*/, " ")
+
+        if desired_definition != current_definition
           Chef::Log.debug \
-            "changed from [#{@current_cib_object.definition}] " \
-            "to [#{desired.definition}]"
+            "changed from [#{current_definition}] " \
+            "to [#{desired_definition}]"
           cmd = desired.reconfigure_command
           execute cmd do
             action :nothing

--- a/chef/cookbooks/pacemaker/libraries/pacemaker/resource/primitive.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/resource/primitive.rb
@@ -74,13 +74,24 @@ class Pacemaker::Resource::Primitive < Pacemaker::Resource
   def self.op_string(ops)
     return "" if !ops || ops.empty?
     ops.sort.map do |op, attrs|
-      attrs.empty? ? nil : "op #{op} " + \
-      attrs.sort.map do |key, value|
-        # Shouldn't be necessary to escape " here since we don't
-        # expect any arbitrary string values, but better to be safe.
-        safe = value.is_a?(String) ? value.gsub('"', '\\"') : value.to_s
-        %'#{key}="#{safe}"'
-      end.join(" ")
+      if attrs.empty?
+        nil
+      else
+        # crm seems to append interval=0 when there are attributes, but no
+        # interval defined, so let's copy that to avoid creating a diff in the
+        # definition
+        unless attrs.key? "interval"
+          attrs = attrs.clone
+          attrs["interval"] = "0"
+        end
+        "op #{op} " + \
+          attrs.sort.map do |key, value|
+            # Shouldn't be necessary to escape " here since we don't
+            # expect any arbitrary string values, but better to be safe.
+            safe = value.is_a?(String) ? value.gsub('"', '\\"') : value.to_s
+            %'#{key}="#{safe}"'
+          end.join(" ")
+      end
     end.compact.join(" ")
   end
 end

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/primitive_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/primitive_spec.rb
@@ -63,7 +63,7 @@ describe Pacemaker::Resource::Primitive do
           "baz" => "qux"
         }
       }
-      expect(fixture.op_string).to eq(%'op monitor baz="qux" foo="bar"')
+      expect(fixture.op_string).to eq(%'op monitor baz="qux" foo="bar" interval="0"')
     end
   end
 


### PR DESCRIPTION
See both commit messages for the details on the two issues that are fixed.