### PR TITLE
pacemaker: Only call "crm configure show" once per transaction

### DIFF
--- a/chef/cookbooks/pacemaker/spec/helpers/crm_mocks.rb
+++ b/chef/cookbooks/pacemaker/spec/helpers/crm_mocks.rb
@@ -6,6 +6,10 @@ class Chef
       module Mocks
         include Chef::RSpec::Mixlib::ShellOut
 
+        def show_all_command
+          "crm --display=plain configure show"
+        end
+
         def show_cib_object_command(name)
           "crm --display=plain configure show #{name}"
         end
@@ -18,6 +22,20 @@ class Chef
         # definition if we wanted to test modification of an existing
         # one.  If the test needs subsequent doubles to return different
         # values then stdout_strings can have more than one element.
+
+        def existing_cib_objects_opts(definitions)
+          {
+            command: show_all_command,
+            stdout: definitions.join("\n")
+          }
+        end
+
+        def nonexistent_cib_objects_opts
+          {
+            command: show_all_command,
+            stdout: ""
+          }
+        end
 
         # Return a Mixlib::ShellOut double which mimics failed
         # execution of a command, raising an exception when #error! is
@@ -45,6 +63,14 @@ class Chef
 
         def nonexistent_cib_object_double(name)
           shellout_double(nonexistent_cib_object_opts(name))
+        end
+
+        def mock_existing_cib_objects(definitions)
+          stub_shellout(existing_cib_objects_opts(definitions))
+        end
+
+        def mock_nonexistent_cib_objects
+          stub_shellout(nonexistent_cib_objects_opts)
         end
 
         def mock_existing_cib_object(name, definition)

--- a/chef/cookbooks/pacemaker/spec/providers/transaction_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/providers/transaction_spec.rb
@@ -37,19 +37,12 @@ describe "Chef::Provider::PacemakerClone" do
     end
 
     it "should not commit anything for pre-existing objects" do
-      stub_shellouts(
-        existing_cib_object_double(
-          Chef::RSpec::Pacemaker::Config::KEYSTONE_PRIMITIVE_NAME,
-          Chef::RSpec::Pacemaker::Config::KEYSTONE_PRIMITIVE_DEFINITION
-        ),
-        existing_cib_object_double(
-          Chef::RSpec::Pacemaker::Config::KEYSTONE_CLONE_NAME,
-          Chef::RSpec::Pacemaker::Config::KEYSTONE_CLONE_DEFINITION
-        ),
-        existing_cib_object_double(
-          Chef::RSpec::Pacemaker::Config::KEYSTONE_LOCATION_NAME,
+      mock_existing_cib_objects(
+        [
+          Chef::RSpec::Pacemaker::Config::KEYSTONE_PRIMITIVE_DEFINITION,
+          Chef::RSpec::Pacemaker::Config::KEYSTONE_CLONE_DEFINITION,
           Chef::RSpec::Pacemaker::Config::KEYSTONE_LOCATION_DEFINITION
-        )
+        ]
       )
 
       converge
@@ -59,12 +52,7 @@ describe "Chef::Provider::PacemakerClone" do
     end
 
     it "should commit all new objects in one go" do
-      mock_nonexistent_cib_object \
-        Chef::RSpec::Pacemaker::Config::KEYSTONE_PRIMITIVE_NAME
-      mock_nonexistent_cib_object \
-        Chef::RSpec::Pacemaker::Config::KEYSTONE_CLONE_NAME
-      mock_nonexistent_cib_object \
-        Chef::RSpec::Pacemaker::Config::KEYSTONE_LOCATION_NAME
+      mock_nonexistent_cib_objects
 
       converge
 
@@ -81,18 +69,12 @@ describe "Chef::Provider::PacemakerClone" do
     end
 
     it "should commit only the missing objects in one go" do
-      stub_shellouts(
-        existing_cib_object_double(
-          Chef::RSpec::Pacemaker::Config::KEYSTONE_PRIMITIVE_NAME,
-          Chef::RSpec::Pacemaker::Config::KEYSTONE_PRIMITIVE_DEFINITION
-        ),
-        nonexistent_cib_object_double(
-          Chef::RSpec::Pacemaker::Config::KEYSTONE_CLONE_NAME,
-        ),
-        nonexistent_cib_object_double(
-          Chef::RSpec::Pacemaker::Config::KEYSTONE_LOCATION_NAME,
-        )
+      mock_existing_cib_objects(
+        [
+          Chef::RSpec::Pacemaker::Config::KEYSTONE_PRIMITIVE_DEFINITION,
+        ]
       )
+
       converge
 
       expect(@chef_run).to \


### PR DESCRIPTION
Previous code was using ::Pacemaker::CIBObject.exists? for each object
in the transaction, which calls "crm configure show" that many times.

crm being a python tool, it can take some time to start, and doing that
so many times is not very optimal. So just run it once and filter the
output to get a list of existing objects.