### PR TITLE
Make new remote nodes get the already existing roles applied for remote cluster

### DIFF
--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -176,16 +176,16 @@ class PacemakerService < ServiceObject
 
       required_barclamp_roles.each do |required_barclamp_role|
         name = required_barclamp_role[:name]
-        unless node.role? name
-          priority = required_barclamp_role[:priority]
-          element_states = required_barclamp_role[:element_states]
+        next if node.role? name
 
-          @logger.debug("[pacemaker] AR: Adding role #{name} to #{node.name} with priority #{priority}")
-          node.add_to_run_list(name, priority, element_states)
-          save_it = true
+        priority = required_barclamp_role[:priority]
+        element_states = required_barclamp_role[:element_states]
 
-          required_pre_chef_calls << { service: required_barclamp_role[:service], barclamp_role: required_barclamp_role[:barclamp_role] }
-        end
+        @logger.debug("[pacemaker] AR: Adding role #{name} to #{node.name} with priority #{priority}")
+        node.add_to_run_list(name, priority, element_states)
+        save_it = true
+
+        required_pre_chef_calls << { service: required_barclamp_role[:service], barclamp_role: required_barclamp_role[:barclamp_role] }
       end
 
       node.save if save_it

--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -115,6 +115,8 @@ class PacemakerService < ServiceObject
   end
 
   def apply_cluster_roles_to_new_nodes_for(cluster_element, relevant_nodes, all_roles)
+    return [] if relevant_nodes.empty?
+
     ### Beware of possible confusion between different level of "roles"!
     # See comment in apply_cluster_roles_to_new_nodes
     required_barclamp_roles = []

--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -129,10 +129,11 @@ class PacemakerService < ServiceObject
     # Inside each barclamp role, identify which role is required
     for cluster_role in cluster_roles do
       service = ServiceObject.get_service(cluster_role.barclamp).new(Rails.logger)
-      runlist_priority_map = cluster_role.override_attributes["element_run_list_order"] || {}
-      role_map = cluster_role.override_attributes["element_states"] || {}
 
       deployment = cluster_role.override_attributes[cluster_role.barclamp]
+      runlist_priority_map = deployment["element_run_list_order"] || {}
+      role_map = deployment["element_states"] || {}
+
       save_it = false
 
       cluster_role.elements.each do |role_name, node_names|


### PR DESCRIPTION
If remote nodes of a cluster are assigned to a compute role (for instance), then when we add a new remote node, this remote node should also get the compute role automatically.