### PR TITLE
dont remove node from unallocated list (bsc#957315)

### DIFF
--- a/crowbar_framework/app/assets/javascripts/barclamps/pacemaker/application.js
+++ b/crowbar_framework/app/assets/javascripts/barclamps/pacemaker/application.js
@@ -95,7 +95,6 @@
     $(document).on('nodeListNodeUnallocated', this.root, function(evt, data) {
       if (self._ignore_event(evt, data)) { return; }
 
-      $(this).find('[data-id="{0}"]'.format(data.id)).remove();
       self.removeJson(data.id, null, "map");
     });
   };


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=957315

when removing a node from pacemaker-cluster-member assignment,
we must not remove it from the list of available (unallocated) nodes