### PR TITLE
crowbar-pacemaker: Improve maintenance check with a default value

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/libraries/maintenance_mode_helpers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/maintenance_mode_helpers.rb
@@ -20,7 +20,7 @@ module CrowbarPacemaker
   module MaintenanceModeHelpers
     def maintenance_mode?
       # See https://bugzilla.suse.com/show_bug.cgi?id=870696
-      !! (%x(crm_attribute -G -N #{node.hostname} -n maintenance -d off -q) =~ /^on$/)
+      !! (`crm_attribute -G -N #{node.hostname} -n maintenance -d off -q` =~ /^on$/)
     end
 
     def record_maintenance_mode_before_this_chef_run

--- a/chef/cookbooks/crowbar-pacemaker/libraries/maintenance_mode_helpers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/maintenance_mode_helpers.rb
@@ -20,7 +20,7 @@ module CrowbarPacemaker
   module MaintenanceModeHelpers
     def maintenance_mode?
       # See https://bugzilla.suse.com/show_bug.cgi?id=870696
-      !! (%x(crm_attribute -G -N #{node.hostname} -n maintenance -q) =~ /^on$/)
+      !! (%x(crm_attribute -G -N #{node.hostname} -n maintenance -d off -q) =~ /^on$/)
     end
 
     def record_maintenance_mode_before_this_chef_run


### PR DESCRIPTION
If there's no value for the attribute, we get:
  Error performing operation: No such device or address

To avoid this, we simply tell crm_attribute what is the default value.