### PR TITLE
crowbar: Fix migrating adding drbd secret

### DIFF
--- a/chef/data_bags/crowbar/migrate/pacemaker/030_add_drbd_secret.rb
+++ b/chef/data_bags/crowbar/migrate/pacemaker/030_add_drbd_secret.rb
@@ -1,5 +1,12 @@
 def upgrade(ta, td, a, d)
-  a["drbd"]["shared_secret"] = ta["drbd"]["shared_secret"]
+  # We use a class variable to set the same password in the proposal and in the
+  # role
+  unless defined?(@@drbd_shared_secret)
+    service = ServiceObject.new "fake-logger"
+    @@drbd_shared_secret = service.random_password
+  end
+  a["drbd"]["shared_secret"] = @@drbd_shared_secret
+
   return a, d
 end
 


### PR DESCRIPTION
We were not generating a new secret on migration, resulting in an empty
secret.