### PR TITLE
avoid spurious connections to pacemaker_remoted (bsc#967388)

### DIFF
--- a/chef/cookbooks/pacemaker/recipes/remote.rb
+++ b/chef/cookbooks/pacemaker/recipes/remote.rb
@@ -56,7 +56,7 @@ ruby_block "wait for pacemaker_remote service to be reachable" do
       # but this would require building a template for
       # /etc/sysconfig/pacemaker on remote nodes, so it's not worth
       # the effort until we really need it.
-      cmd = "netcat -t localhost 3121 </dev/null"
+      cmd = "lsof -i tcp:3121 >/dev/null"
       until ::Kernel.system(cmd)
         Chef::Log.debug("pacemaker_remote not reachable yet")
         sleep(5)


### PR DESCRIPTION
Pacemaker currently makes it too easy to take over a remote, simply by connecting to its TCP port.  So until that bug is fixed, we should avoid making an actual connection, and instead simply check via `lsof` that the port is being listened on.

https://bugzilla.suse.com/show_bug.cgi?id=967388