### PR TITLE
only check for Pacemaker remote TCP port in LISTEN state

### DIFF
--- a/chef/cookbooks/pacemaker/recipes/remote.rb
+++ b/chef/cookbooks/pacemaker/recipes/remote.rb
@@ -56,7 +56,7 @@ ruby_block "wait for pacemaker_remote service to be reachable" do
       # but this would require building a template for
       # /etc/sysconfig/pacemaker on remote nodes, so it's not worth
       # the effort until we really need it.
-      cmd = "lsof -i tcp:3121 >/dev/null"
+      cmd = "lsof -i tcp:3121 -sTCP:LISTEN >/dev/null"
       until ::Kernel.system(cmd)
         Chef::Log.debug("pacemaker_remote not reachable yet")
         sleep(5)


### PR DESCRIPTION
This eliminates the very small corner case that an unexpected connection
was established from one remote node to another, e.g. manually for
testing.