### PR TITLE
Handle DRBD in degraded cluster better

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/providers/drbd.rb
+++ b/chef/cookbooks/crowbar-pacemaker/providers/drbd.rb
@@ -44,7 +44,13 @@ action :create do
     dirty ||= true if resource["master"] != is_master
 
     if dirty && resource["configured"]
-      raise "Configuration for DRBD resource #{name} has changed. If this is really wanted, please manually set node['drbd']['rsc']['#{name}']['configured'] to false with knife; the content of the DRBD resource will be lost!"
+      fmt = "%s / %s / %s"
+      old = fmt % [resource["fstype"], resource["remote_host"], resource["master"]]
+      new = fmt % [fstype, remote_host, is_master]
+      raise "Configuration for DRBD resource #{name} has changed from " \
+            "#{old} to #{new}. If this is really wanted, please manually " \
+            "set node['drbd']['rsc']['#{name}']['configured'] to false with " \
+            "knife; the content of the DRBD resource will be lost!"
     end
 
     node["drbd"]["rsc"][name]["lvm_size"] = lvm_size

--- a/chef/cookbooks/crowbar-pacemaker/providers/drbd.rb
+++ b/chef/cookbooks/crowbar-pacemaker/providers/drbd.rb
@@ -38,6 +38,18 @@ action :create do
   if node["drbd"]["rsc"].key?(name)
     resource = node["drbd"]["rsc"][name]
 
+    if remote_host.nil?
+      if resource["configured"] && !resource["remote_host"].nil?
+        Chef::Log.warn "Couldn't find remote host for #{node[:fqdn]}; " \
+          "has node been removed from the cluster? " \
+          "Keeping previous value of " + \
+          resource["remote_host"]
+        remote_host = resource["remote_host"]
+      else
+        raise "Couldn't find remote host for #{node[:fqdn]}"
+      end
+    end
+
     dirty = false
     dirty ||= true if resource["fstype"] != fstype
     dirty ||= true if resource["remote_host"] != remote_host


### PR DESCRIPTION
I'm not 100% sure this is the right approach yet, but it's probably better than nothing.  I don't get why the fenced founder loses its `pacemaker-cluster-member` role, since it's showing in Ready state (despite `crowbar_join` bailing at the `/var/spool/corosync/block_automatic_start` test).  (I can't find anything in any logs explaining why the role was removed from node1.)  But that means that the Chef search on the non-founder to find a DRBD peer fails to find the founder.  At this point I'm not sure whether it's better to keep the previous value of `remote_host` (as this PR does), or fail the chef-client run.  But either way we need to improve the error handling.