### PR TITLE
Make Pacemaker retry start actions if they fail (bsc#965886)

### DIFF
--- a/chef/cookbooks/pacemaker/templates/default/crm-initial.conf.erb
+++ b/chef/cookbooks/pacemaker/templates/default/crm-initial.conf.erb
@@ -1,6 +1,7 @@
 property $id="cib-bootstrap-options" \
         stonith-enabled="<%= @stonith_enabled %>" \
         no-quorum-policy="<%= @no_quorum_policy %>" \
+        start-failure-is-fatal=false \
         placement-strategy="balanced"
 op_defaults $id="op-options" \
         timeout="<%= @op_default_timeout %>" \


### PR DESCRIPTION
**DO NOT MERGE YET - this is a significant cluster-wide change which needs thorough failover testing, and may even be too invasive to backport to SOC6 or 5.**

If `neutron-ha-tool` fails to start (e.g. because `neutron-server` is not yet listening on a socket due the daemon still being in the startup phase) then we should retry a few times on the same node, rather than immediately migrating to the other node. We already have `migration-threshold` defaulting to 3, which makes sense in this case.

Also in general, retrying startup of services seems like a good idea. Retries happen immediately so it should not significantly slow down fail-overs and increase service downtime.  If in the future we only want to allow retries for certain resources, we can change the cluster-wide default `migration-threshold` to `1` (or `0`?) and then increase it for individual resources.

However this is not a fully reliable fix, since it's conceivable that the daemon could stay in the startup phase for longer than `(migration-threshold * number-of-nodes)` retries.  So we will also need to make start-up of `neutron-server` (and maybe other daemons) asynchronous, i.e. blocking until the API endpoint is actually usable.

https://bugzilla.suse.com/show_bug.cgi?id=965886