### PR TITLE
[3.0] interleave Apache clones to minimise disruption (bsc#965886)

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb
@@ -61,7 +61,10 @@ transaction_objects << "pacemaker_primitive[#{service_name}]"
 clone_name = "cl-#{service_name}"
 pacemaker_clone clone_name do
   rsc service_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta ({
+    "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node),
+    "interleave" => "true",
+  })
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end


### PR DESCRIPTION
(There is a corresponding commit to crowbar-openstack, in which
there are many more clones than in this repository.)

By default, Pacemaker clones aren't interleaved.  This means that if
Pacemaker wants to restart a dead clone instance, and there is an order
constraint on that clone, it will do the same restart on all other
nodes, even if all the others are healthy.

More details on interleaving are here:

  https://www.hastexo.com/resources/hints-and-kinks/interleaving-pacemaker-clones/

This behaviour is far more disruptive than we want.  For example, in

  https://bugzilla.suse.com/show_bug.cgi?id=965886

we saw that when a network node dies and Pacemaker wants to stop the
instance of cl-g-neutron-agents on that node, it also stops and restarts
the same clone instances on the healthy nodes.  This means there is a
small window in which there are no neutron agents running anywhere.  If
neutron-ha-tool attempts a router migration during this window, it will
fail, at which point things start to go badly wrong.

In general, the cloned (i.e. active/active) services on our controller
and compute nodes should all behave like independent vertical stacks, so
that a failure on one node should not cause ripple effects on other
nodes.  Apache is one example of that, and even though there aren't
currently any ordering constraints which would require interleaving,
we may add them in the future.

(cherry picked from commit 9589cfcdf78de37492dc6d2a03f7b7a16671a4ff)

This is a backport of https://github.com/crowbar/crowbar-ha/pull/98
