### PR TITLE
pin rake to 10.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ end
 
 unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"
   group :test do
-    gem "rspec", "~> 3.1.0"
+    gem "rake", "~> 10.0"
     gem "simplecov", require: false
 
     if ENV["CODECLIMATE_REPO_TOKEN"]


### PR DESCRIPTION
Older `rspec-core` versions use `#last_comment`, which `rake` 11.x removed support for.  We're still waiting for the `rspec-core` fix to land, since 3.5.x is still in pre-release:

  rspec/rspec-core#2205

so in the mean time, let's stick with rake 10.x.