### PR TITLE
Added http-keep-alive option to haproxy defaults

### DIFF
--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -17,7 +17,8 @@ defaults
 	option  dontlognull
 	option  redispatch
 	retries 3
-	timeout http-request 5s
+	timeout http-request 10s
+	timeout http-keep-alive 10s
 	timeout queue 1m
 	timeout connect 5s
 	timeout client 3h


### PR DESCRIPTION
We were using the http-request for haproxy with a 5s timeout. This
option only addresses the initial part of the HTTP negotiation. Once
the HTTP session is established we should use a shorter timeout
for idling connections with the http-keep-alive option. This option
if not set gets the same value as http-request timeout.

This patch will help fix problems with 'nova boot --poll', because
the connections usually ended at the same time a new request was
coming, leading to connection refused errors.

References:
- https://trello.com/c/m9a3MQYS
- https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4.2-timeout%20http-keep-alive