### PR TITLE
Add "role recipes" with the goal of simplifying the roles

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/metadata.rb
+++ b/chef/cookbooks/crowbar-pacemaker/metadata.rb
@@ -8,6 +8,7 @@ version "0.1"
 
 depends "drbd"
 depends "haproxy"
+depends "hawk"
 depends "lvm"
 depends "pacemaker"
 

--- a/chef/cookbooks/crowbar-pacemaker/recipes/role_hawk_server.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/role_hawk_server.rb
@@ -1,0 +1,25 @@
+#
+# Copyright 2016, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "pacemaker"
+role = "hawk-server"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "hawk::server"
+end

--- a/chef/cookbooks/crowbar-pacemaker/recipes/role_hawk_server.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/role_hawk_server.rb
@@ -14,12 +14,4 @@
 # limitations under the License.
 #
 
-barclamp = "pacemaker"
-role = "hawk-server"
-
-# if nil, then this means all states are valid
-states_for_role = node[barclamp]["element_states"][role]
-
-if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
-  include_recipe "hawk::server"
-end
+include_recipe "hawk::server"

--- a/chef/cookbooks/crowbar-pacemaker/recipes/role_pacemaker_cluster_member.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/role_pacemaker_cluster_member.rb
@@ -1,0 +1,25 @@
+#
+# Copyright 2016, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "pacemaker"
+role = "pacemaker-cluster-member"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "crowbar-pacemaker::default"
+end

--- a/chef/cookbooks/crowbar-pacemaker/recipes/role_pacemaker_remote.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/role_pacemaker_remote.rb
@@ -14,5 +14,4 @@
 # limitations under the License.
 #
 
-include_recipe "crowbar-pacemaker::default"
-include_recipe "crowbar-pacemaker::remote_delegator"
+include_recipe "crowbar-pacemaker::remote"

--- a/chef/roles/hawk-server.rb
+++ b/chef/roles/hawk-server.rb
@@ -1,7 +1,5 @@
 name "hawk-server"
 description "Hawk web server"
-run_list(
-         "recipe[hawk::server]"
-)
+run_list("recipe[crowbar-pacemaker::role_hawk_server]")
 default_attributes
 override_attributes

--- a/chef/roles/pacemaker-cluster-member.rb
+++ b/chef/roles/pacemaker-cluster-member.rb
@@ -1,8 +1,5 @@
 name "pacemaker-cluster-member"
 description "Pacemaker cluster member"
-run_list(
-  "recipe[crowbar-pacemaker::default]",
-  "recipe[crowbar-pacemaker::remote_delegator]"
-)
+run_list("recipe[crowbar-pacemaker::role_pacemaker_cluster_member]")
 default_attributes
 override_attributes

--- a/chef/roles/pacemaker-remote.rb
+++ b/chef/roles/pacemaker-remote.rb
@@ -1,7 +1,5 @@
 name "pacemaker-remote"
 description "Pacemaker remote cluster member"
-run_list(
-  "recipe[crowbar-pacemaker::remote]"
-)
+run_list("recipe[crowbar-pacemaker::role_pacemaker_remote]")
 default_attributes
 override_attributes


### PR DESCRIPTION
We want the roles to only reference one recipe, so that we can put some
intelligence in that recipe:

 - in a first step, we will stop changing the run list of a node
   depending on its state, and instead have the role recipe "decide"
   whether something should be done or not, depending on the state. This
   will solve the issue that the search results for nodes are not
   reliable when a node is in some state that is not "readying",
   "applying" or "ready".

   Very concretely: many recipes are using searches to find attributes
   of another barclamp. The recipes do not expect the search to return
   an empty result (and that's okay, because we know that there must be
   a glance server when we deploy nova, due to barclamp dependencies),
   but that could happen in the past when the node was in "problem" or
   rebooting.

 - in a later step, we might want to have a new attribute that will tell
   us which role to apply instead of applying everything.

More generally speaking, it's actually wrong to pretend that a node
stops having a role because it's, say, rebooting. A glance server is
always a glance server.

(cherry picked from commit 61ad653d4f2611ebf53d808d3f4c1e46d4b03683)

Fix hound issues

(cherry picked from commit 09ef863d6c6b702e7fda82089194fe871437e726)