### PR TITLE
crowbar-pacemaker: Use Barclamp::Inventory.Network objects

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/stonith.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/stonith.rb
@@ -108,10 +108,11 @@ when "ipmi_barclamp"
     end
 
     stonith_node_name = pacemaker_node_name(cluster_node)
+    bmc_net = Barclamp::Inventory.get_network_by_type(cluster_node, "bmc")
 
     params = {}
     params["hostname"] = stonith_node_name
-    params["ipaddr"] = cluster_node[:crowbar][:network][:bmc][:address]
+    params["ipaddr"] = bmc_net.address
     params["userid"] = cluster_node[:ipmi][:bmc_user]
     params["passwd"] = cluster_node[:ipmi][:bmc_password]
 

--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -359,10 +359,10 @@ class PacemakerService < ServiceObject
     end
 
     # set corosync attributes based on what we got in the proposal
-    admin_net = Chef::DataBag.load("crowbar/admin_network") rescue nil
+    admin_net = founder.get_network_by_type("admin")
 
     role.default_attributes["corosync"] ||= {}
-    role.default_attributes["corosync"]["bind_addr"] = admin_net["network"]["subnet"]
+    role.default_attributes["corosync"]["bind_addr"] = admin_net["subnet"]
 
     role.default_attributes["corosync"]["mcast_addr"] = role.default_attributes["pacemaker"]["corosync"]["mcast_addr"]
     role.default_attributes["corosync"]["mcast_port"] = role.default_attributes["pacemaker"]["corosync"]["mcast_port"]


### PR DESCRIPTION
We do this instead of accessing attributes, in order to centralize the
location of the network definitions, so it can be changed.

Should go with https://github.com/crowbar/crowbar-core/pull/510