### PR TITLE
crowbar, crowbar-pacemaker: Add helpers to fetch the VIP of a hostname

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/helpers.rb
@@ -106,6 +106,22 @@ module CrowbarPacemakerHelper
     end
   end
 
+  # Returns the VIP matching a specific virtual hostname used by a cluster.
+  # Note that vhostname is not a FQDN, but a short hostname.
+  # This returns nil if the network is not admin or public, or if node is not
+  # member of a cluster.
+  def self.cluster_vip(node, net, vhostname = nil)
+    return nil unless cluster_enabled?(node)
+    # only support this for admin & public; it's not needed elsewhere, and
+    # saves us some checks
+    return nil unless ["admin", "public"].include? net
+
+    vhostname = cluster_vhostname(node) if vhostname.nil?
+
+    net_db = Chef::DataBagItem.load("crowbar", "#{net}_network").raw_data
+    net_db["allocated_by_name"]["#{vhostname}.#{node[:domain]}"]["address"]
+  end
+
   # Performs a Chef search and returns an Array of Node objects for
   # all nodes in the same cluster as the given node, or an empty array
   # if the node isn't in a cluster.  Can optionally filter by role.

--- a/chef/cookbooks/crowbar-pacemaker/recipes/haproxy.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/haproxy.rb
@@ -51,14 +51,7 @@ if node[:pacemaker][:haproxy][:clusters].key?(cluster_name) && node[:pacemaker][
 
   # Create VIP for HAProxy
   node[:pacemaker][:haproxy][:clusters][cluster_name][:networks].each do |network, enabled|
-    net_db = data_bag_item("crowbar", "#{network}_network")
-    raise "#{network}_network data bag missing?!" unless net_db
-    fqdn = "#{cluster_vhostname}.#{node[:domain]}"
-    unless net_db["allocated_by_name"][fqdn]
-      raise "Missing allocation for #{fqdn} in #{network} network"
-    end
-    ip_addr = net_db["allocated_by_name"][fqdn]["address"]
-
+    ip_addr = CrowbarPacemakerHelper.cluster_vip(node, network)
     vip_primitive = "vip-#{network}-#{cluster_vhostname}"
     pacemaker_primitive vip_primitive do
       agent "ocf:heartbeat:IPaddr2"

--- a/crowbar_framework/app/models/pacemaker_service_object.rb
+++ b/crowbar_framework/app/models/pacemaker_service_object.rb
@@ -154,6 +154,19 @@ class PacemakerServiceObject < ServiceObject
       remote_nodes = pacemaker_proposal.override_attributes["pacemaker"]["elements"]["pacemaker-remote"]
       remote_nodes || []
     end
+
+    # Convert vhostname to the VIP that is assigned to it in network.
+    # Note that vhostname is a FQDN, as returned by
+    # cluster_vhostname_from_element.
+    # This returns nil if the network is not admin or public.
+    def vhostname_to_vip(vhostname, net)
+      # only support this for admin & public; it's not needed elsewhere, and
+      # saves us some checks
+      return nil unless ["admin", "public"].include? net
+
+      net_db = Chef::DataBagItem.load("crowbar", "#{net}_network").raw_data
+      net_db["allocated_by_name"][vhostname]["address"]
+    end
   end
 
   def expand_remote_nodes(cluster)


### PR DESCRIPTION
We have code in several locations that does this, and it feels better to
have a helper to not have too many copy & paste. It will also make it
easier to change the implementation of how IP assignments are stored.