### PR TITLE
chef: Use new CrowbarRoleRecipe.node_state_valid_for_role helper

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/metadata.rb
+++ b/chef/cookbooks/crowbar-pacemaker/metadata.rb
@@ -11,5 +11,6 @@ depends "haproxy"
 depends "hawk"
 depends "lvm"
 depends "pacemaker"
+depends "utils"
 
 recommends "crowbar-openstack"

--- a/chef/cookbooks/crowbar-pacemaker/recipes/role_hawk_server.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/role_hawk_server.rb
@@ -14,4 +14,6 @@
 # limitations under the License.
 #
 
-include_recipe "hawk::server"
+if CrowbarRoleRecipe.node_state_valid_for_role?(node, "pacemaker", "hawk-server")
+  include_recipe "hawk::server"
+end

--- a/chef/cookbooks/crowbar-pacemaker/recipes/role_pacemaker_cluster_member.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/role_pacemaker_cluster_member.rb
@@ -14,5 +14,7 @@
 # limitations under the License.
 #
 
-include_recipe "crowbar-pacemaker::default"
-include_recipe "crowbar-pacemaker::remote_delegator"
+if CrowbarRoleRecipe.node_state_valid_for_role?(node, "pacemaker", "pacemaker-cluster-member")
+  include_recipe "crowbar-pacemaker::default"
+  include_recipe "crowbar-pacemaker::remote_delegator"
+end

--- a/chef/cookbooks/crowbar-pacemaker/recipes/role_pacemaker_remote.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/role_pacemaker_remote.rb
@@ -14,4 +14,6 @@
 # limitations under the License.
 #
 
-include_recipe "crowbar-pacemaker::remote"
+if CrowbarRoleRecipe.node_state_valid_for_role?(node, "pacemaker", "pacemaker-remote")
+  include_recipe "crowbar-pacemaker::remote"
+end


### PR DESCRIPTION
This is used in role recipes to decide whether the role should be run or
not. This will allow us to stop rebuilding the run_list based on the
state of the nodes, since we move the logic in the role recipes.