### PR TITLE
haproxy: Make the sections for haproxy config persistent on each node

### DIFF
--- a/chef/cookbooks/haproxy/providers/loadbalancer.rb
+++ b/chef/cookbooks/haproxy/providers/loadbalancer.rb
@@ -61,3 +61,9 @@ action :create do
   node["haproxy"]["sections"][new_resource.type] ||= {}
   node["haproxy"]["sections"][new_resource.type][new_resource.name] = section
 end
+
+action :delete do
+  node["haproxy"]["sections"].keys.each do |type|
+    node["haproxy"]["sections"][type].delete(new_resource.name)
+  end
+end

--- a/chef/cookbooks/haproxy/providers/loadbalancer.rb
+++ b/chef/cookbooks/haproxy/providers/loadbalancer.rb
@@ -58,5 +58,6 @@ action :create do
   end
   section["servers"] = new_resource.servers
 
-  node.default["haproxy"]["sections"][new_resource.type][new_resource.name] = section
+  node["haproxy"]["sections"][new_resource.type] ||= {}
+  node["haproxy"]["sections"][new_resource.type][new_resource.name] = section
 end

--- a/chef/cookbooks/haproxy/resources/loadbalancer.rb
+++ b/chef/cookbooks/haproxy/resources/loadbalancer.rb
@@ -17,7 +17,7 @@
 
 # This is largely copied/inspired from https://github.com/hw-cookbooks/haproxy
 
-actions :create
+actions :create, :delete
 default_action :create
 
 attribute :name,    kind_of: String,  name_attribute: true


### PR DESCRIPTION
Until now, we were saving the sections as a default attribute, so that
they would be removed on every new run, resulting in the config being
regenerated from scratch. The downside of this is that all active roles
that use a loadbalancer resource must always be used in the chef run,
otherwise we lose part of the config. And this goes against our goal of
running only the strict minimal recipes when required.