### PR TITLE
crowbar: Update for Crowbar::Settings.domain new API

### DIFF
--- a/crowbar_framework/app/models/pacemaker_service_object.rb
+++ b/crowbar_framework/app/models/pacemaker_service_object.rb
@@ -82,7 +82,7 @@ class PacemakerServiceObject < ServiceObject
       # substitute one with the other.
       # Similar code is in the cookbook:
       # CrowbarPacemakerHelper.cluster_vhostname
-      "cluster-#{name.gsub("_", "-")}.#{ChefObject.cloud_domain}"
+      "cluster-#{name.gsub("_", "-")}.#{Crowbar::Settings.domain}"
     end
 
     # This is the key that allows to find out that an element item is a

--- a/crowbar_framework/app/models/pacemaker_service_object.rb
+++ b/crowbar_framework/app/models/pacemaker_service_object.rb
@@ -82,7 +82,7 @@ class PacemakerServiceObject < ServiceObject
       # substitute one with the other.
       # Similar code is in the cookbook:
       # CrowbarPacemakerHelper.cluster_vhostname
-      "cluster-#{name.gsub("_", "-")}.#{Crowbar::Settings.domain}"
+      "cluster-#{name.tr("_", "-")}.#{Crowbar::Settings.domain}"
     end
 
     # This is the key that allows to find out that an element item is a


### PR DESCRIPTION
ChefObject.cloud_domain got moved to Crowbar::Settings.domain.

Needed because https://github.com/crowbar/crowbar-core/pull/519 was merged. Gating won't be green without https://github.com/crowbar/crowbar-openstack/pull/432