### PR TITLE
Ensure the autostart blocking file is cleaned up

### DIFF
--- a/chef/cookbooks/corosync/recipes/service.rb
+++ b/chef/cookbooks/corosync/recipes/service.rb
@@ -144,6 +144,16 @@ if node[:corosync][:require_clean_for_autostart]
       )
     end
 
+    template "/etc/systemd/system/#{node[:corosync][:platform][:service_name]}.service" do
+      source "corosync.service.erb"
+      owner "root"
+      group "root"
+      mode "0644"
+      variables(
+        service_name: corosync_shutdown
+      )
+    end
+
     bash "reload systemd after #{corosync_shutdown} update" do
       code "systemctl daemon-reload"
       action :nothing

--- a/chef/cookbooks/corosync/templates/default/corosync-shutdown-cleaner.service.erb
+++ b/chef/cookbooks/corosync/templates/default/corosync-shutdown-cleaner.service.erb
@@ -1,5 +1,6 @@
 [Unit]
 Description=Clean file blocking <%= @service_name %> start after fencing
+Requires=<%= @service_name %>.service
 Before=<%= @service_name %>.service
 
 [Service]

--- a/chef/cookbooks/corosync/templates/default/corosync.service.erb
+++ b/chef/cookbooks/corosync/templates/default/corosync.service.erb
@@ -1,0 +1,28 @@
+[Unit]
+Description=Corosync Cluster Engine
+ConditionKernelCommandLine=!nocluster
+Requires=network-online.target
+Requires=<%= @service_name %>.service
+After=<%= @service_name %>.service
+After=network-online.target
+StopWhenUnneeded=yes
+
+[Service]
+ExecStart=/usr/share/corosync/corosync start
+ExecStop=/usr/share/corosync/corosync stop
+Type=forking
+
+# The following config is for corosync with enabled watchdog service.
+#
+#  When corosync watchdog service is being enabled and using with
+#  pacemaker.service, and if you want to exert the watchdog when a
+#  corosync process is terminated abnormally,
+#  uncomment the line of the following Restart= and RestartSec=.
+#Restart=on-failure
+#  Specify a period longer than soft_margin as RestartSec.
+#RestartSec=70
+#  rewrite according to environment.
+#ExecStartPre=/sbin/modprobe softdog soft_margin=60
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The systemd corosync service did not delete the
/var/spool/corosync/block_automatic_start when shut down properly,
so restarting corosync was broken. The involved service files now
contain the correct ordering.

See also https://bugzilla.suse.com/show_bug.cgi?id=983617