### PR TITLE
Updated haproxy cfg for version 1.6

### DIFF
--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -37,7 +37,8 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
 <% node[:haproxy][:sections].keys.sort.each do |type| -%>
   <% node[:haproxy][:sections][type].keys.sort.each do |name| -%>
     <% content = node[:haproxy][:sections][type][name] -%>
-<%= type %> <%= name %> <%= content[:address] %>:<%= content[:port] %>
+<%= type %> <%= name %>
+    bind <%= content[:address] %>:<%= content[:port] %>
     <% if content[:use_ssl] -%>
        mode tcp
        balance source


### PR DESCRIPTION
The 'listen' command in haproxy configuration file no longer supports
setting the listening address right away. Instead it has to be put in a
'bind' command.

This change should be backwards compatible with previous haproxy
versions.