### PR TITLE
Adapt to changes in drbd-overview

### DIFF
--- a/chef/cookbooks/drbd/libraries/overview.rb
+++ b/chef/cookbooks/drbd/libraries/overview.rb
@@ -18,7 +18,7 @@ require "chef/shell_out"
 
 module DrbdOverview
   def self.get(resource)
-    cmd = "drbd-overview"
+    cmd = "drbd-overview --color=no"
     output = Chef::ShellOut.new(cmd).run_command.stdout
 
     resource_output = ""
@@ -34,26 +34,32 @@ module DrbdOverview
     if resource_output.empty?
       nil
     else
-      # Example:
-      # ["0:postgresql/0", "Connected", "Primary/Secondary", "UpToDate/Diskless", "C", "r----- /var/lib/pgsql xfs 4.0G 67M 4.0G 2%"]
-      parsed = resource_output.split(" ", 6)
+      # Examples:
+      # "0:postgresql/0  Connected(2*) Primar/Second UpToDa/Incons"
+      # "0:postgresql/0  Connected(2*) Primar/Second UpToDa/UpToDa /var/lib/pgsql    xfs 5.0G 94M 4.9G 2%"
+      parsed = resource_output.split " "
       item_1, item_2 = parsed[2].split("/", 2)
       state_1, state_2 = parsed[3].split("/", 2)
+
+      # Example: "0:postgresql/0  Connected(2*) Primar/Second UpToDate(2*)"
+      state_2 = state_1 if state_2.nil? && state_1.include?("2*")
+      # Example: "1:rabbitmq/0    Connected(2*) Secondary(2*) Incons/Incons"
+      item_2 = item_1 if item_2.nil? && item_1.include?("2*")
 
       overview = {}
       overview["state"] = parsed[1]
 
       overview["primary"] = nil
-      if item_1 == "Primary"
+      if item_1.include? "Primar"
         overview["primary"] = state_1
-      elsif item_2 == "Primary"
+      elsif item_2.include? "Primar"
         overview["primary"] = state_2
       end
 
       overview["secondary"] = nil
-      if item_1 == "Secondary"
+      if item_1.include? "Second"
         overview["secondary"] = state_1
-      elsif item_2 == "Secondary"
+      elsif item_2.include? "Second"
         overview["secondary"] = state_2
       end
 


### PR DESCRIPTION
drbd-overview has changed in SP2 and it will not give us the previous "Unconfigured" status.

Now we need another way to find out when we want to execute `drbdadm -- --force create-md` for initialization.