### PR TITLE
Switch to node[:crowbar_ohai] for getting libvirt uuid

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/stonith.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/stonith.rb
@@ -133,16 +133,15 @@ when "libvirt"
     CrowbarPacemakerHelper.remote_nodes(node)
 
   all_nodes.each do |cluster_node|
-    manufacturer = cluster_node[:dmi][:system][:manufacturer] rescue "unknown"
-    unless %w(Bochs QEMU).include? manufacturer
+    unless cluster_node[:crowbar_ohai][:libvirt][:guest_uuid]
       message = "Node #{cluster_node[:hostname]} does not seem to be running in libvirt."
       Chef::Log.fatal(message)
       raise message
     end
 
     # We need to know the domain to interact with for each cluster member; it
-    # turns out that libvirt puts the domain UUID in DMI
-    domain_id = cluster_node[:dmi][:system][:uuid]
+    # turns out the domain UUID is accessible via ohai
+    domain_id = cluster_node[:crowbar_ohai][:libvirt][:guest_uuid]
 
     stonith_node_name = pacemaker_node_name(cluster_node)
 

--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -547,13 +547,8 @@ class PacemakerService < ServiceObject
       end
       members.each do |member|
         node = NodeObject.find_node_by_name(member)
-        manufacturer = node[:dmi][:system][:manufacturer] rescue "unknown"
-        unless %w(Bochs QEMU).include? manufacturer
-          validation_error I18n.t(
-            "barclamp.#{bc_name}.validation.libvirt",
-            member: member
-          )
-        end
+        next if node[:crowbar_ohai][:libvirt][:guest_uuid]
+        validation_error I18n.t("barclamp.#{bc_name}.validation.libvirt", member: member)
       end
     else
       validation_error I18n.t(


### PR DESCRIPTION
node[:crowbar_ohai][:libvirt][:guestuuid] is maintained by crowbar's
ohai plugin to avoid the use of the architecture specific node[:dmi]
subtree.

Alternative to #143
Requires: crowbar/crowbar-core#677