### PR TITLE
fix corosync.conf values (bsc#1001164)

### DIFF
--- a/chef/cookbooks/corosync/templates/default/corosync.conf.v2.erb
+++ b/chef/cookbooks/corosync/templates/default/corosync.conf.v2.erb
@@ -15,6 +15,26 @@ totem {
 	crypto_cipher: aes256
 	crypto_hash: sha1
 
+	# How long before declaring a token lost (ms)
+	token:          5000
+
+	# How many token retransmits before forming a new configuration
+	token_retransmits_before_loss_const: 10
+
+	# How long to wait for join messages in the membership protocol (ms)
+	join:           60
+
+	# How long to wait for consensus to be achieved before starting
+	# a new round of membership configuration (ms)
+	consensus:      6000
+
+	# Turn off the virtual synchrony filter
+	vsftype:        none
+
+	# Number of messages that may be sent by one processor on
+	# receipt of the token
+	max_messages:   20
+
 	# Limit generated nodeids to 31-bits (positive signed integers)
 	# you would set it to 'yes', the new option 'new' means wiping 
 	# off the highest bit in network order to avoid possible nodeid


### PR DESCRIPTION
Our `corosync.conf.v2` template was based on a version from SLE HA which had some tunings accidentally dropped in the migration from SLE11.  In particular, some of the timeouts were too aggressive.

https://bugzilla.suse.com/show_bug.cgi?id=1001164