### PR TITLE
Helpers for creating upgrade related location constraints

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/definitions/upgraded_only_location_for.rb
+++ b/chef/cookbooks/crowbar-pacemaker/definitions/upgraded_only_location_for.rb
@@ -1,0 +1,26 @@
+#
+# Copyright 2016, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+define :upgraded_only_location_for do
+  resource = params[:name]
+  location_name = "l-#{resource}-upgraded-only"
+  pacemaker_location location_name do
+    definition CrowbarPacemakerHelper.upgraded_only_location(location_name, resource)
+    action :update
+    only_if { CrowbarPacemakerHelper.being_upgraded?(node) }
+  end
+  location_name
+end

--- a/chef/cookbooks/crowbar-pacemaker/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/helpers.rb
@@ -291,4 +291,12 @@ module CrowbarPacemakerHelper
 
     servers
   end
+
+  # Helper method to provides a convenient way to create Pacemaker
+  # location constraints which limit resources to only run on node that has already been upgraded
+  def self.upgraded_only_location(location, service)
+    # resource-discovery=exclusive means that Pacemaker will detect
+    # if a resource is running where it shouldn't be (i.e. on a pre-upgrade node), and then stop it
+    "location #{location} #{service} resource-discovery=exclusive rule 0: pre-upgrade eq false"
+  end
 end


### PR DESCRIPTION
Requires https://github.com/crowbar/crowbar-ha/pull/146

Usage in a recipe:

```
upgrade_location_name = upgraded_only_location_for clone_name
transaction_objects << "pacemaker_location[#{upgrade_location_name}]" if CrowbarPacemakerHelper.being_upgraded?(node)
```
