### PR TITLE
[3.0] Fix undefined method `sort' for nil:NilClass

### DIFF
--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -154,7 +154,8 @@ class PacemakerService < ServiceObject
         end
 
         expanded_nodes.sort!
-        old_expanded_nodes = deployment["elements_expanded"][role_name].sort
+        old_expanded_nodes = deployment["elements_expanded"][role_name] || []
+        old_expanded_nodes.sort!
 
         if old_expanded_nodes != expanded_nodes
           deployment["elements_expanded"][role_name] = expanded_nodes


### PR DESCRIPTION
It can happened that deployment["elements_expanded"][role_name]
can be nil. This will cause

"Failed to apply the proposal: exception before calling chef (undefined method `sort' for nil:NilClass)"
