### PR TITLE
Method for changing the cluster founder to given node

### DIFF
--- a/crowbar_framework/app/models/api/pacemaker.rb
+++ b/crowbar_framework/app/models/api/pacemaker.rb
@@ -92,11 +92,17 @@ module Api
           Rails.logger.warning("No cluster founder found. Making #{name} the new founder anyway.")
         else
           old_founder[:pacemaker][:founder] = false
+          if old_founder[:drbd] && old_founder[:drbd][:rsc]
+            old_founder[:drbd][:rsc].each { |_, res| res[:master] = false }
+          end
           old_founder.save
         end
 
         # 3. mark given node as founder
         new_founder[:pacemaker][:founder] = true
+        if new_founder[:drbd] && new_founder[:drbd][:rsc]
+          new_founder[:drbd][:rsc].each { |_, res| res[:master] = true }
+        end
         new_founder.save
       end
 

--- a/crowbar_framework/app/models/api/pacemaker.rb
+++ b/crowbar_framework/app/models/api/pacemaker.rb
@@ -66,6 +66,40 @@ module Api
         ret
       end
 
+      def set_node_as_founder(name)
+        # 1. find the cluster new founder is in
+        new_founder = NodeObject.find_node_by_name(name)
+        if new_founder.nil?
+          Rails.logger.error("Node #{name} not found!")
+          return false
+        end
+        unless new_founder[:pacemaker]
+          Rails.logger.error("Node #{name} does not have pacemaker setup")
+          return false
+        end
+        if new_founder[:pacemaker][:founder]
+          Rails.logger.debug("Node #{name} is already the cluster founder.")
+          return true
+        end
+
+        # 2. find the current cluster founder in the same cluster
+        cluster_env = new_founder[:pacemaker][:config][:environment]
+        old_founder = NodeObject.find(
+          "pacemaker_founder:true AND pacemaker_config_environment:#{cluster_env}"
+        ).first
+
+        if old_founder.nil?
+          Rails.logger.warning("No cluster founder found. Making #{name} the new founder anyway.")
+        else
+          old_founder[:pacemaker][:founder] = false
+          old_founder.save
+        end
+
+        # 3. mark given node as founder
+        new_founder[:pacemaker][:founder] = true
+        new_founder.save
+      end
+
       def repocheck
         Api::Node.repocheck(addon: "ha")
       end


### PR DESCRIPTION
This is supposed to be called from `models/api/upgrade.rb` after the first node in cluster is upgraded.

So... the logic should be correct, but the question is if the method belongs in this place or elsewhere.

We could split it into pieces (like `cluster_for_node` etc.) and put them into PacemakerServiceObject, but that does not seem right as well, because we do not need the service object for anything.
