### PR TITLE
Adapt the DRBD settings to the changes of cluster founder.

### DIFF
--- a/crowbar_framework/app/models/api/pacemaker.rb
+++ b/crowbar_framework/app/models/api/pacemaker.rb
@@ -69,6 +69,35 @@ module Api
       def repocheck
         Api::Node.repocheck(addon: "ha")
       end
+
+      # Adapt DRBD information to possible changes of cluster founder
+      def adapt_drbd_settings(founder_name)
+        founder = NodeObject.find_node_by_name(founder_name)
+
+        # nothing to be done if there's no DRBD setup
+        return true unless founder[:drbd]
+
+        modified = false
+        founder[:drbd][:rsc].each do |_, resource|
+          unless resource[:master]
+            resource[:master] = true
+            modified = true
+          end
+        end
+        return true unless modified
+
+        founder.save
+
+        # adapt the info for remaining node
+        cluster_env = founder[:pacemaker][:config][:environment]
+        non_founder = NodeObject.find(
+          "pacemaker_founder:false AND pacemaker_config_environment:#{cluster_env}"
+        ).first
+        non_founder[:drbd][:rsc].each do |_, resource|
+          resource[:master] = false
+        end
+        non_founder.save
+      end
     end
   end
 end


### PR DESCRIPTION
During the upgrade, we do not want to reconfigure DRBD.
So we need to explicitely adapt the settings in node[:drbd] to
the changes of cluster founder, otherwise they would look as inconsistent
with the node setup.

This is what I want to prevent: https://github.com/crowbar/crowbar-ha/blob/master/chef/cookbooks/crowbar-pacemaker/providers/drbd.rb#L56

UPDATE: likely obsoleted by second commit of https://github.com/crowbar/crowbar-ha/pull/152
