### PR TITLE
don't restart corosync when corosync.conf changes (bsc#1001164)

### DIFF
--- a/chef/cookbooks/corosync/recipes/config.rb
+++ b/chef/cookbooks/corosync/recipes/config.rb
@@ -56,8 +56,17 @@ template "/etc/corosync/corosync.conf" do
     transport: node[:corosync][:transport]
   )
 
-  service_name = node[:pacemaker][:platform][:service_name] rescue nil
-  if service_name
-    notifies :restart, "service[#{service_name}]"
-  end
+  # If the config parameters are changed, it's too risky to just
+  # restart the cluster - this could happen on all cluster nodes at a
+  # similar time and cause a significant outage.  Fortunately it's
+  # possible to instead reload the config whilst keeping corosync running,
+  # via corosync-cfgtool -R.
+end
+
+execute "reload corosync.conf" do
+  command "corosync-cfgtool -R"
+  user "root"
+  group "root"
+  action :nothing
+  subscribes :run, "template[/etc/corosync/corosync.conf]", :immediately
 end

--- a/chef/cookbooks/corosync/recipes/config.rb
+++ b/chef/cookbooks/corosync/recipes/config.rb
@@ -68,5 +68,5 @@ execute "reload corosync.conf" do
   user "root"
   group "root"
   action :nothing
-  subscribes :run, "template[/etc/corosync/corosync.conf]", :immediately
+  subscribes :run, "template[/etc/corosync/corosync.conf]", :delayed
 end


### PR DESCRIPTION
If the config parameters are changed, it's too risky to just restart the
cluster - this could happen on all cluster nodes at a similar time and
cause a significant outage.  Fortunately it's possible to instead reload
the config whilst keeping corosync running, via corosync-cfgtool -R.

https://bugzilla.suse.com/show_bug.cgi?id=1001164