### PR TITLE
[3.0] pacemaker: Force use of old rack version

### DIFF
--- a/chef/cookbooks/pacemaker/Gemfile
+++ b/chef/cookbooks/pacemaker/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 #gem 'berkshelf',  '~> 2.0'
+gem "rack", "< 2.0.0"
 gem "rake"
 
 group :test, :development do


### PR DESCRIPTION
It seems new versions requires a newer version of rack, that requires
ruby 2.2.2. See https://travis-ci.org/crowbar/crowbar-ha/jobs/142499249

(cherry picked from commit 5191cfd7dcac21df8e688d9429d59edefc75b1c0)