### PR TITLE
Do not require crowbar-pacemaker cookbook to run when we configure HA in openstack

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/attributes.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/attributes.rb
@@ -1,0 +1,28 @@
+#
+# Author:: Vincent Untz
+# Cookbook Name:: crowbar-pacemaker
+# Recipe:: attributes
+#
+# Copyright 2016, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+node[:pacemaker][:attributes].each do |attr, value|
+  execute %(set pacemaker attribute "#{attr}" to "#{value}") do
+    command %(crm node attribute #{node[:hostname]} set "#{attr}" "#{value}")
+    # The cluster only does a transition if the attribute value changes,
+    # so checking the value before setting would only slow things down
+    # for no benefit.
+  end
+end

--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -60,15 +60,7 @@ crowbar_pacemaker_sync_mark "create-pacemaker_setup" do
   revision node[:pacemaker]["crowbar-revision"]
 end
 
-node[:pacemaker][:attributes].each do |attr, value|
-  execute %(set pacemaker attribute "#{attr}" to "#{value}") do
-    command %(crm node attribute #{node[:hostname]} set "#{attr}" "#{value}")
-    # The cluster only does a transition if the attribute value changes,
-    # so checking the value before setting would only slow things down
-    # for no benefit.
-  end
-end
-
+include_recipe "crowbar-pacemaker::attributes"
 include_recipe "crowbar-pacemaker::maintenance-mode"
 include_recipe "crowbar-pacemaker::mutual_ssh"
 

--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -85,6 +85,5 @@ node[:pacemaker][:attributes].each do |attr, value|
   end
 end
 
-include_recipe "crowbar-pacemaker::haproxy"
 include_recipe "crowbar-pacemaker::maintenance-mode"
 include_recipe "crowbar-pacemaker::mutual_ssh"

--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -73,7 +73,7 @@ node[:pacemaker][:platform][:resource_packages][:openstack].each do |pkg|
 end
 
 if node[:pacemaker][:drbd][:enabled]
-  include_recipe "crowbar-pacemaker::drbd"
+  include_recipe "crowbar-pacemaker::drbd_setup"
 end
 
 node[:pacemaker][:attributes].each do |attr, value|

--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -60,17 +60,7 @@ crowbar_pacemaker_sync_mark "create-pacemaker_setup" do
   revision node[:pacemaker]["crowbar-revision"]
 end
 
-# if we ever want to not have a hard dependency on openstack here, we can have
-# Crowbar set a node[:pacemaker][:resource_agents] attribute based on available
-# barclamps, and do:
-# node[:pacemaker][:resource_agents].each do |resource_agent|
-#   node[:pacemaker][:platform][:resource_packages][resource_agent].each do |pkg|
-#     package pkg
-#   end
-# end
-node[:pacemaker][:platform][:resource_packages][:openstack].each do |pkg|
-  package pkg
-end
+include_recipe "crowbar-pacemaker::openstack"
 
 if node[:pacemaker][:drbd][:enabled]
   include_recipe "crowbar-pacemaker::drbd_setup"

--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -60,12 +60,6 @@ crowbar_pacemaker_sync_mark "create-pacemaker_setup" do
   revision node[:pacemaker]["crowbar-revision"]
 end
 
-include_recipe "crowbar-pacemaker::openstack"
-
-if node[:pacemaker][:drbd][:enabled]
-  include_recipe "crowbar-pacemaker::drbd_setup"
-end
-
 node[:pacemaker][:attributes].each do |attr, value|
   execute %(set pacemaker attribute "#{attr}" to "#{value}") do
     command %(crm node attribute #{node[:hostname]} set "#{attr}" "#{value}")
@@ -77,3 +71,9 @@ end
 
 include_recipe "crowbar-pacemaker::maintenance-mode"
 include_recipe "crowbar-pacemaker::mutual_ssh"
+
+include_recipe "crowbar-pacemaker::openstack"
+
+if node[:pacemaker][:drbd][:enabled]
+  include_recipe "crowbar-pacemaker::drbd_setup"
+end

--- a/chef/cookbooks/crowbar-pacemaker/recipes/drbd_setup.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/drbd_setup.rb
@@ -24,7 +24,7 @@ lvm_disk = nil
 unclaimed_disks = BarclampLibrary::Barclamp::Inventory::Disk.unclaimed(node).sort
 claimed_disks = BarclampLibrary::Barclamp::Inventory::Disk.claimed(node, claim_string).sort
 
-if claimed_disks.empty? and not unclaimed_disks.empty?
+if claimed_disks.empty? && !unclaimed_disks.empty?
   unclaimed_disks.each do |disk|
     if disk.claim(claim_string)
       Chef::Log.info("#{claim_string}: Claimed #{disk.name}")

--- a/chef/cookbooks/crowbar-pacemaker/recipes/drbd_setup.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/drbd_setup.rb
@@ -1,0 +1,66 @@
+#
+# Cookbook Name:: crowbar-pacemaker
+# Recipe:: drbd
+#
+# Copyright 2014, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+claim_string = "LVM_DRBD"
+lvm_group = "drbd"
+lvm_disk = nil
+
+unclaimed_disks = BarclampLibrary::Barclamp::Inventory::Disk.unclaimed(node).sort
+claimed_disks = BarclampLibrary::Barclamp::Inventory::Disk.claimed(node, claim_string).sort
+
+if claimed_disks.empty? and not unclaimed_disks.empty?
+  unclaimed_disks.each do |disk|
+    if disk.claim(claim_string)
+      Chef::Log.info("#{claim_string}: Claimed #{disk.name}")
+      lvm_disk = disk
+      break
+    else
+      Chef::Log.info("#{claim_string}: Ignoring #{disk.name}")
+    end
+  end
+else
+  lvm_disk = claimed_disks.first
+end
+
+if lvm_disk.nil?
+  message = "There is no suitable disk for LVM for DRBD!"
+  Chef::Log.fatal(message)
+  raise message
+end
+
+# SLE11 only
+if node[:platform] == "suse" && node[:platform_version].to_f < 12.0
+  # Make sure that LVM is setup on boot
+  service "boot.lvm" do
+    action [:enable]
+  end
+end
+
+include_recipe "lvm::default"
+
+lvm_physical_volume lvm_disk.name
+
+lvm_volume_group lvm_group do
+  physical_volumes [lvm_disk.name]
+end
+
+include_recipe "drbd::install"
+include_recipe "drbd::config"
+# this will start drbd
+include_recipe "drbd::default"

--- a/chef/cookbooks/crowbar-pacemaker/recipes/drbd_setup.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/drbd_setup.rb
@@ -62,5 +62,10 @@ end
 
 include_recipe "drbd::install"
 include_recipe "drbd::config"
-# this will start drbd
-include_recipe "drbd::default"
+
+# Disable drbd as it should never be started on boot (pacemaker should do it)
+# However, start it because on initial setup, we currently require drbd to be
+# running.
+service "drbd" do
+  action [:disable, :start]
+end

--- a/chef/cookbooks/crowbar-pacemaker/recipes/openstack.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/openstack.rb
@@ -1,0 +1,31 @@
+#
+# Author:: Vincent Untz
+# Cookbook Name:: crowbar-pacemaker
+# Recipe:: openstack
+#
+# Copyright 2016, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# if we ever want to not have a hard dependency on openstack here, we can have
+# Crowbar set a node[:pacemaker][:resource_agents] attribute based on available
+# barclamps, and do:
+# node[:pacemaker][:resource_agents].each do |resource_agent|
+#   node[:pacemaker][:platform][:resource_packages][resource_agent].each do |pkg|
+#     package pkg
+#   end
+# end
+node[:pacemaker][:platform][:resource_packages][:openstack].each do |pkg|
+  package pkg
+end

--- a/chef/cookbooks/crowbar-pacemaker/recipes/remote.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/remote.rb
@@ -38,17 +38,7 @@ end
 include_recipe "crowbar-pacemaker::pacemaker_authkey"
 include_recipe "pacemaker::remote"
 
-# if we ever want to not have a hard dependency on openstack here, we can have
-# Crowbar set a node[:pacemaker][:resource_agents] attribute based on available
-# barclamps, and do:
-# node[:pacemaker][:resource_agents].each do |resource_agent|
-#   node[:pacemaker][:platform][:resource_packages][resource_agent].each do |pkg|
-#     package pkg
-#   end
-# end
-node[:pacemaker][:platform][:resource_packages][:openstack].each do |pkg|
-  package pkg
-end
+include_recipe "crowbar-pacemaker::openstack"
 
 ruby_block "mark node as ready for pacemaker_remote" do
   block do

--- a/chef/cookbooks/crowbar-pacemaker/recipes/remote.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/remote.rb
@@ -38,11 +38,11 @@ end
 include_recipe "crowbar-pacemaker::pacemaker_authkey"
 include_recipe "pacemaker::remote"
 
-include_recipe "crowbar-pacemaker::openstack"
-
 ruby_block "mark node as ready for pacemaker_remote" do
   block do
     node[:pacemaker][:remote_setup] = true
     node.save
   end
 end
+
+include_recipe "crowbar-pacemaker::openstack"

--- a/chef/cookbooks/crowbar-pacemaker/recipes/remote_attributes.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/remote_attributes.rb
@@ -1,0 +1,31 @@
+#
+# Author:: Vincent Untz
+# Cookbook Name:: crowbar-pacemaker
+# Recipe:: attributes
+#
+# Copyright 2016, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+CrowbarPacemakerHelper.remote_nodes(node).each do |remote|
+  remote[:pacemaker][:attributes].each do |attr, value|
+    execute %(set pacemaker attribute "#{attr}" to "#{value}" on remote #{remote[:hostname]}) do
+      command %(crm node attribute remote-#{remote[:hostname]} set "#{attr}" "#{value}")
+      # The cluster only does a transition if the attribute value changes,
+      # so checking the value before setting would only slow things down
+      # for no benefit.
+      only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+    end
+  end
+end

--- a/chef/cookbooks/crowbar-pacemaker/recipes/remote_delegator.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/remote_delegator.rb
@@ -50,14 +50,6 @@ CrowbarPacemakerHelper.remote_nodes(node, true).each do |remote|
     action :commit_new
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
-
-  remote[:pacemaker][:attributes].each do |attr, value|
-    execute %(set pacemaker attribute "#{attr}" to "#{value}" on remote #{remote[:hostname]}) do
-      command %(crm node attribute remote-#{remote[:hostname]} set "#{attr}" "#{value}")
-      # The cluster only does a transition if the attribute value changes,
-      # so checking the value before setting would only slow things down
-      # for no benefit.
-      only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-    end
-  end
 end
+
+include_recipe "crowbar-pacemaker::remote_attributes"


### PR DESCRIPTION
We make it possible to not run the crowbar-pacemaker cookbook when we run some OpenStack cookbook that use HA and require some specific setup (for drbd or haproxy, for instance).

This depends on and needs to be merged at the same time as: https://github.com/crowbar/crowbar-openstack/pull/635

Note: this includes a patch similar to https://github.com/crowbar/crowbar-ha/pull/116