### PR TITLE
crowbar-pacemaker: Do not start or restart drbd service (bsc#971771)

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/drbd_setup.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/drbd_setup.rb
@@ -64,8 +64,6 @@ include_recipe "drbd::install"
 include_recipe "drbd::config"
 
 # Disable drbd as it should never be started on boot (pacemaker should do it)
-# However, start it because on initial setup, we currently require drbd to be
-# running.
 service "drbd" do
-  action [:disable, :start]
+  action :disable
 end

--- a/chef/cookbooks/drbd/providers/resource.rb
+++ b/chef/cookbooks/drbd/providers/resource.rb
@@ -61,6 +61,12 @@ action :create do
   end
   p.run_action(:run)
 
+  drbdadm_up = execute "drbdadm up #{name}" do
+    only_if { drbd_resource_template.updated_by_last_action? }
+    action :nothing
+  end
+  drbdadm_up.run_action(:run)
+
   # claim primary based off of master
   execute "drbdadm -- --overwrite-data-of-peer primary #{name}" do
     only_if { drbd_resource_template.updated_by_last_action? && master }

--- a/chef/cookbooks/drbd/providers/resource.rb
+++ b/chef/cookbooks/drbd/providers/resource.rb
@@ -61,17 +61,6 @@ action :create do
   end
   p.run_action(:run)
 
-  if p.updated_by_last_action?
-    # we would usually do something like:
-    #    notifies :restart, "service[drbd]", :immediately
-    # in the execute above; but the notification doesn't work (probably because
-    # we're already in a LWRP). So we hack around this.
-    service "drbd(#{name})" do
-      service_name "drbd"
-      action :nothing
-    end.run_action(:restart)
-  end
-
   overview = DrbdOverview.get(name)
   if !overview.nil? && overview["state"] != "Unconfigured" && overview["primary"].nil?
     # claim primary based off of master

--- a/chef/cookbooks/drbd/providers/resource.rb
+++ b/chef/cookbooks/drbd/providers/resource.rb
@@ -55,11 +55,11 @@ action :create do
 
   # first pass only, initialize drbd
   # for disks re-usage from old resources we will run with force option
-  p = execute "drbdadm -- --force create-md #{name}" do
+  drbdadm_create_md = execute "drbdadm -- --force create-md #{name}" do
     only_if { drbd_resource_template.updated_by_last_action? }
     action :nothing
   end
-  p.run_action(:run)
+  drbdadm_create_md.run_action(:run)
 
   drbdadm_up = execute "drbdadm up #{name}" do
     only_if { drbd_resource_template.updated_by_last_action? }

--- a/chef/cookbooks/drbd/providers/resource.rb
+++ b/chef/cookbooks/drbd/providers/resource.rb
@@ -61,21 +61,18 @@ action :create do
   end
   p.run_action(:run)
 
-  overview = DrbdOverview.get(name)
-  if !overview.nil? && overview["state"] != "Unconfigured" && overview["primary"].nil?
-    # claim primary based off of master
-    execute "drbdadm -- --overwrite-data-of-peer primary #{name}" do
-      only_if { master }
-      action :nothing
-    end.run_action(:run)
+  # claim primary based off of master
+  execute "drbdadm -- --overwrite-data-of-peer primary #{name}" do
+    only_if { drbd_resource_template.updated_by_last_action? && master }
+    action :nothing
+  end.run_action(:run)
 
-    # you may now create a filesystem on the device, use it as a raw block device
-    # for disks re-usage from old resources we will run with force option
-    execute "mkfs -t #{fstype} -f #{device}" do
-      only_if { master }
-      action :nothing
-    end.run_action(:run)
-  end
+  # you may now create a filesystem on the device, use it as a raw block device
+  # for disks re-usage from old resources we will run with force option
+  execute "mkfs -t #{fstype} -f #{device}" do
+    only_if { drbd_resource_template.updated_by_last_action? && master }
+    action :nothing
+  end.run_action(:run)
 
   unless mount.nil? or mount.empty?
     directory mount do
@@ -90,7 +87,10 @@ action :create do
       action :nothing
     end.run_action(:mount)
   end
+end
 
+action :wait do
+  name = new_resource.name
   begin
     Timeout.timeout(20) do
       while true

--- a/chef/cookbooks/drbd/resources/resource.rb
+++ b/chef/cookbooks/drbd/resources/resource.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-actions :create
+actions :create, :wait
 default_action :create
 
 attribute :name,        kind_of: String,  name_attribute: true


### PR DESCRIPTION
It should only be started by pacemaker (to avoid ownership conflict with
systemd), and therefore we should not require drbd to be running to do
the setup.

This is a followup of 52d11b7 and is required to properly fix
https://bugzilla.suse.com/show_bug.cgi?id=971771

(the three other commits are required to keep things working)