### PR TITLE
[3.0] travis: Use rake < 12.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ source "https://rubygems.org"
 gem "sprockets-standalone", "~> 1.2.1"
 
 group :development do
+  gem "rake", "< 12.0.0"
   gem "closure-compiler", "~> 1.1.10"
   gem "sass", "~> 3.2.19"
   gem "sprockets", "~> 2.11.0"


### PR DESCRIPTION
Rake 12.0.0 got released on Dec 6 but our rspec version still uses
removed code.

(cherry picked from commit d7dc20fe4be08348d6f85f3aa40588e8d10e6a65)