### PR TITLE
upgrade: Look for one more upgrade step when checking if node is being upgraded

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/helpers.rb
@@ -34,7 +34,7 @@ module CrowbarPacemakerHelper
   # Check if the node is currently in some upgrade phase
   def self.being_upgraded?(node)
     upgrade_step = node["crowbar_wall"]["crowbar_upgrade_step"] || "none"
-    upgrade_step == "prepare-os-upgrade"
+    ["prepare-os-upgrade", "done_os_upgrade"].include? upgrade_step
   end
 
   # Returns the number of corosync (or non-remote) nodes in the cluster.


### PR DESCRIPTION
New "done_os_upgrade" step identifies the situation when node
has been upgraded, but we still want to skip synchronization,
because other nodes in cluster may still have the old system.

It's introduced by https://github.com/crowbar/crowbar-core/pull/840