### PR TITLE
crowbar-pacemaker: Do not start or restart drbd service (bsc#971771)

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/drbd.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/drbd.rb
@@ -68,8 +68,6 @@ crowbar_pacemaker_drbd_create_internal "create drbd resources" do
 end
 
 # Disable drbd as it should never be started on boot (pacemaker should do it)
-# However, start it because on initial setup, we currently require drbd to be
-# running.
 service "drbd" do
-  action [:disable, :start]
+  action :disable
 end

--- a/chef/cookbooks/crowbar-pacemaker/recipes/drbd.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/drbd.rb
@@ -67,4 +67,9 @@ crowbar_pacemaker_drbd_create_internal "create drbd resources" do
   lvm_group lvm_group
 end
 
-include_recipe "drbd::default"
+# Disable drbd as it should never be started on boot (pacemaker should do it)
+# However, start it because on initial setup, we currently require drbd to be
+# running.
+service "drbd" do
+  action [:disable, :start]
+end

--- a/chef/cookbooks/drbd/providers/resource.rb
+++ b/chef/cookbooks/drbd/providers/resource.rb
@@ -60,17 +60,6 @@ action :create do
   end
   p.run_action(:run)
 
-  if p.updated_by_last_action?
-    # we would usually do something like:
-    #    notifies :restart, "service[drbd]", :immediately
-    # in the execute above; but the notification doesn't work (probably because
-    # we're already in a LWRP). So we hack around this.
-    service "drbd(#{name})" do
-      service_name "drbd"
-      action :nothing
-    end.run_action(:restart)
-  end
-
   overview = DrbdOverview.get(name)
   if !overview.nil? && overview["state"] != "Unconfigured" && overview["primary"].nil?
     # claim primary based off of master

--- a/chef/cookbooks/drbd/providers/resource.rb
+++ b/chef/cookbooks/drbd/providers/resource.rb
@@ -58,6 +58,12 @@ action :create do
   end
   p.run_action(:run)
 
+  drbdadm_up = execute "drbdadm up #{name}" do
+    only_if { drbd_resource_template.updated_by_last_action? }
+    action :nothing
+  end
+  drbdadm_up.run_action(:run)
+
   # claim primary based off of master
   execute "drbdadm -- --overwrite-data-of-peer primary #{name}" do
     only_if { drbd_resource_template.updated_by_last_action? && master }

--- a/chef/cookbooks/drbd/providers/resource.rb
+++ b/chef/cookbooks/drbd/providers/resource.rb
@@ -31,7 +31,7 @@ action :create do
   raise "Remote node #{remote_host} not found!" if remote_nodes.empty?
   remote = remote_nodes.first
 
-  t = template "/etc/drbd.d/#{name}.res" do
+  drbd_resource_template = template "/etc/drbd.d/#{name}.res" do
     cookbook "drbd"
     source "resource.erb"
     variables(
@@ -48,12 +48,12 @@ action :create do
     group "root"
     action :nothing
   end
-  t.run_action(:create)
+  drbd_resource_template.run_action(:create)
 
   # first pass only, initialize drbd
   # for disks re-usage from old resources we will run with force option
   p = execute "drbdadm -- --force create-md #{name}" do
-    only_if { t.updated_by_last_action? }
+    only_if { drbd_resource_template.updated_by_last_action? }
     action :nothing
   end
   p.run_action(:run)

--- a/chef/cookbooks/drbd/providers/resource.rb
+++ b/chef/cookbooks/drbd/providers/resource.rb
@@ -58,21 +58,18 @@ action :create do
   end
   p.run_action(:run)
 
-  overview = DrbdOverview.get(name)
-  if !overview.nil? && overview["state"] != "Unconfigured" && overview["primary"].nil?
-    # claim primary based off of master
-    execute "drbdadm -- --overwrite-data-of-peer primary #{name}" do
-      only_if { master }
-      action :nothing
-    end.run_action(:run)
+  # claim primary based off of master
+  execute "drbdadm -- --overwrite-data-of-peer primary #{name}" do
+    only_if { drbd_resource_template.updated_by_last_action? && master }
+    action :nothing
+  end.run_action(:run)
 
-    # you may now create a filesystem on the device, use it as a raw block device
-    # for disks re-usage from old resources we will run with force option
-    execute "mkfs -t #{fstype} -f #{device}" do
-      only_if { master }
-      action :nothing
-    end.run_action(:run)
-  end
+  # you may now create a filesystem on the device, use it as a raw block device
+  # for disks re-usage from old resources we will run with force option
+  execute "mkfs -t #{fstype} -f #{device}" do
+    only_if { drbd_resource_template.updated_by_last_action? && master }
+    action :nothing
+  end.run_action(:run)
 
   unless mount.nil? or mount.empty?
     directory mount do
@@ -87,7 +84,10 @@ action :create do
       action :nothing
     end.run_action(:mount)
   end
+end
 
+action :wait do
+  name = new_resource.name
   begin
     Timeout.timeout(20) do
       while true

--- a/chef/cookbooks/drbd/providers/resource.rb
+++ b/chef/cookbooks/drbd/providers/resource.rb
@@ -52,11 +52,11 @@ action :create do
 
   # first pass only, initialize drbd
   # for disks re-usage from old resources we will run with force option
-  p = execute "drbdadm -- --force create-md #{name}" do
+  drbdadm_create_md = execute "drbdadm -- --force create-md #{name}" do
     only_if { drbd_resource_template.updated_by_last_action? }
     action :nothing
   end
-  p.run_action(:run)
+  drbdadm_create_md.run_action(:run)
 
   drbdadm_up = execute "drbdadm up #{name}" do
     only_if { drbd_resource_template.updated_by_last_action? }

--- a/chef/cookbooks/drbd/resources/resource.rb
+++ b/chef/cookbooks/drbd/resources/resource.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-actions :create
+actions :create, :wait
 default_action :create
 
 attribute :name,        kind_of: String,  name_attribute: true


### PR DESCRIPTION
It should only be started by pacemaker (to avoid ownership conflict with
systemd), and therefore we should not require drbd to be running to do
the setup.

https://bugzilla.suse.com/show_bug.cgi?id=971771

Backport of https://github.com/crowbar/crowbar-ha/pull/165

Some of the patches come from the SP2 port in master, but are actually relevant here.