### PR TITLE
Fallback to dmi[:system][:uuid] if new ohai attributes are not available

### DIFF
--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -771,7 +771,11 @@ class PacemakerService < ServiceObject
 
         # We need to know the domain to interact with for each cluster member; it
         # turns out the domain UUID is accessible via ohai
-        domain_id = cluster_node["crowbar_ohai"]["libvirt"]["guest_uuid"]
+        if cluster_node["crowbar_ohai"] && cluster_node["crowbar_ohai"]["libvirt"]
+          domain_id = cluster_node["crowbar_ohai"]["libvirt"]["guest_uuid"]
+        else
+          domain_id = cluster_node["dmi"]["system"]["uuid"]
+        end
 
         params = {}
         params["hostlist"] = "#{stonith_node_name}:#{domain_id}"


### PR DESCRIPTION
Using new ohai attribute was introduced in commit
3b4cb98502eaa07543bc401ec6ea99e3959549ab.

During 6-7 upgrade, we do not have these new attributes yet when we
are running migrations.