### PR TITLE
upgrade: Do not ignore founder change when the node is founder

### DIFF
--- a/crowbar_framework/app/models/api/pacemaker.rb
+++ b/crowbar_framework/app/models/api/pacemaker.rb
@@ -79,7 +79,6 @@ module Api
         end
         if new_founder[:pacemaker][:founder]
           Rails.logger.debug("Node #{name} is already the cluster founder.")
-          return true
         end
 
         # 2. find the current cluster founder in the same cluster


### PR DESCRIPTION
It is possible that (e.g. due to some previous error) node is marked
as founder but drbd master value is not correctly set.