### PR TITLE
haproxy: Fix server checks when ssl is used

### DIFF
--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -51,7 +51,11 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
     <% end -%>
 
     <% content[:servers].each do |server| -%>
+      <% if content[:use_ssl] -%>
+	server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check-ssl verify none inter 2000 rise 2 fall 5
+      <% else -%>
 	server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check inter 2000 rise 2 fall 5
+      <% end -%>
     <% end -%>
 
   <% end -%>


### PR DESCRIPTION
Right now, we end up with traces like this in syslog:

```
neutron-server[15962]: Traceback (most recent call last):
neutron-server[15962]: File "/usr/lib/python2.7/site-packages/eventlet/greenpool.py", line 82, in _spawn_n_impl
neutron-server[15962]: func(*args, **kwargs)
neutron-server[15962]: File "/usr/lib/python2.7/site-packages/eventlet/wsgi.py", line 719, in process_request
neutron-server[15962]: proto.__init__(sock, address, self)
neutron-server[15962]: File "/usr/lib64/python2.7/SocketServer.py", line 655, in __init__
neutron-server[15962]: self.handle()
neutron-server[15962]: File "/usr/lib64/python2.7/BaseHTTPServer.py", line 340, in handle
neutron-server[15962]: self.handle_one_request()
neutron-server[15962]: File "/usr/lib/python2.7/site-packages/eventlet/wsgi.py", line 330, in handle_one_request
neutron-server[15962]: self.raw_requestline = self.rfile.readline(self.server.url_length_limit)
neutron-server[15962]: File "/usr/lib64/python2.7/socket.py", line 476, in readline
neutron-server[15962]: data = self._sock.recv(self._rbufsize)
neutron-server[15962]: File "/usr/lib/python2.7/site-packages/eventlet/green/ssl.py", line 200, in recv
neutron-server[15962]: read = self.read(buflen)
neutron-server[15962]: File "/usr/lib/python2.7/site-packages/eventlet/green/ssl.py", line 139, in read
neutron-server[15962]: super(GreenSSLSocket, self).read, *args, **kwargs)
neutron-server[15962]: File "/usr/lib/python2.7/site-packages/eventlet/green/ssl.py", line 113, in _call_trampolining
neutron-server[15962]: return func(*a, **kw)
neutron-server[15962]: File "/usr/lib64/python2.7/ssl.py", line 627, in read
neutron-server[15962]: v = self._sslobj.read(len or 1024)
neutron-server[15962]: error: [Errno 104] Connection reset by peer
```

This is because the checks are not ssl-enabled.

We also specify "verify none" so that it works with "insecure" mode;
this is actually fine because only the check will ignore certificates;
for everything else, haproxy will simply forward the tcp packets, and
have no role in certificate validation.