### PR TITLE
haproxy: Configure stats interface through unix sockets

### DIFF
--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -9,6 +9,7 @@ global
 	user <%= node[:haproxy][:platform][:user] %>
 	group <%= node[:haproxy][:platform][:group] %>
 	daemon
+	stats socket /var/lib/haproxy/stats.sock user haproxy group haproxy mode 0640 level operator
 
 defaults
 	log     global


### PR DESCRIPTION
This is useful to get info from haproxy, and to do some basic changes.