### PR TITLE
crowbar-pacemaker: don't tell systemd to enable drbd (bsc#971771)

### DIFF
--- a/chef/cookbooks/drbd/recipes/default.rb
+++ b/chef/cookbooks/drbd/recipes/default.rb
@@ -28,6 +28,6 @@ service "drbd" do
   if node["drbd"]["rsc"].empty?
     action :nothing
   else
-    action [:enable, :start]
+    action [:disable, :start]
   end
 end


### PR DESCRIPTION
  https://bugzilla.suse.com/show_bug.cgi?id=971771

We only want DRBD started by Pacemaker, with the possible exception of
during initial DRBD setup.  If it gets started by systemd, systemd
will
believe it owns the service, in which case during system shutdown it
will prematurely shut down DRBD without regard for any of the other
services and resources depending on it.  Instead we want Pacemaker to
stop things in the correct order, even taking care of inter-node
dependencies.

This fix will not be sufficient by itself, since we still need to
address:

  https://bugzilla.suse.com/show_bug.cgi?id=980341

Thanks to Adam Spiers <aspiers@suse.com> (for the fix & for writing
the commit
message)

(cherry picked from commit 52d11b7d94cc0f0eb14be3462b7cd2d6814e41ac)