### PR TITLE
fix remote primitive existence test

### DIFF
--- a/chef/cookbooks/pacemaker/libraries/pacemaker/cib_object.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/cib_object.rb
@@ -34,10 +34,21 @@ module Pacemaker
           end
 
           if lines_for_def.empty?
-            # in case our attempt to only extract the definition we're
-            # interested in failed, play it safe and return the output
+            # In case our attempt to only extract the definition we're
+            # interested in failed, return nil to indicate the object
+            # doesn't exist.  This is particularly important in the
+            # corner case where an object like
+            #
+            #    node remote-d52-54-77-77-77-03:remote
+            #
+            # exists but the corresponding
+            #
+            #    primitive remote-d52-54-77-77-77-03
+            #
+            # doesn't, because in this case, "crm configure show remote-d52-54-77-77-77-03"
+            # will show the node object, which is not the one we want.
             ::Chef::Log.warn "Failed to extract definition for #{name} from:\n#{cmd.stdout}"
-            cmd.stdout
+            nil
           else
             lines_for_def.join("")
           end

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/cib_object_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/cib_object_spec.rb
@@ -85,12 +85,12 @@ describe Pacemaker::CIBObject do
     end
 
     describe "#type" do
-      it "should raise an error without a valid definition" do
-        expect { ::Pacemaker::CIBObject.from_name(fixture.name) }.
-          to raise_error(
-            RuntimeError,
-            "Couldn't extract CIB object type from 'nonsense'"
-          )
+      it "should return nil without a valid definition" do
+        expect(Chef::Log).to receive(:warn).with(
+          "Failed to extract definition for #{fixture.name} from:\nnonsense"
+        )
+        result = ::Pacemaker::CIBObject.from_name(fixture.name)
+        expect(result).to be_nil
       end
     end
   end


### PR DESCRIPTION
**Still needs manual testing**

Fix a corner case where a remote primitive was incorrectly being reported as existing, due to `#crm_configure_show` returning a string like `node remote-d52-54-77-77-77-03:remote`, causing `#exists?` to return true.

This corner case arose during upgrade of a controller node, during `crowbar_join` after all primitives except for vips, drbd, and stonith resources were removed in anticipation of a switch to systemd agents.  At that point, the :update action of the remote primitive failed because it didn't know how to handle an object of type `node`, and this action happens before the containing transaction which would have recreated the primitive.

Since remote primitives use the `ocf:pacemaker:remote` agent, it probably makes sense to exclude them from this removal of primitives which happens during the upgrade, thereby eliminating this corner case.  However there may be other corner cases, so we should still ensure that `#exists?` always returns the correct value.