### PR TITLE
[UNTESTED] Fix remote node maintenance (bsc#983617)

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/files/default/pacemaker_maintenance_handlers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/files/default/pacemaker_maintenance_handlers.rb
@@ -49,7 +49,7 @@ class Chef
 
           if maintenance_mode?
             Chef::Log.info("Taking node out of Pacemaker maintenance mode")
-            system("crm --wait node ready")
+            system("crm --wait node ready #{pacemaker_node_name}")
           else
             # This shouldn't happen, and suggests that one of the recipes
             # is interfering in a way it shouldn't.

--- a/chef/cookbooks/crowbar-pacemaker/libraries/maintenance_mode_helpers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/maintenance_mode_helpers.rb
@@ -18,14 +18,17 @@ module CrowbarPacemaker
   # A mixin for Chef::Pacemaker::Handler subclasses, and also for the
   # Chef::Provider::PacemakerService LWRP.
   module MaintenanceModeHelpers
-    def maintenance_mode?
-      pacemaker_node = if !node[:pacemaker].nil? && node[:pacemaker][:is_remote]
+    def pacemaker_node_name
+      if !node[:pacemaker].nil? && node[:pacemaker][:is_remote]
         "remote-#{node.hostname}"
       else
         node.hostname
       end
+    end
+
+    def maintenance_mode?
       # See https://bugzilla.suse.com/show_bug.cgi?id=870696
-      !! (`crm_attribute -G -N #{pacemaker_node} -n maintenance -d off -q` =~ /^on$/)
+      !! (`crm_attribute -G -N #{pacemaker_node_name} -n maintenance -d off -q` =~ /^on$/)
     end
 
     def record_maintenance_mode_before_this_chef_run

--- a/chef/cookbooks/crowbar-pacemaker/libraries/maintenance_mode_helpers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/maintenance_mode_helpers.rb
@@ -68,7 +68,7 @@ module CrowbarPacemaker
       elsif maintenance_mode?
         Chef::Log.info("Something else already placed this node in Pacemaker maintenance mode")
       else
-        execute "crm --wait node maintenance" do
+        execute "crm --wait node maintenance #{pacemaker_node_name}" do
           action :nothing
         end.run_action(:run)
         set_maintenance_mode_via_this_chef_run

--- a/chef/cookbooks/pacemaker/attributes/default.rb
+++ b/chef/cookbooks/pacemaker/attributes/default.rb
@@ -18,7 +18,7 @@ when "suse"
   default[:pacemaker][:platform][:packages] =
     %w(pacemaker crmsh fence-agents)
   default[:pacemaker][:platform][:remote_packages] =
-    %w(pacemaker-remote fence-agents)
+    %w(pacemaker-remote pacemaker-cli crmsh fence-agents)
   default[:pacemaker][:platform][:sbd_packages] =
     %w(sbd)
 else


### PR DESCRIPTION
We need `crm` and `crm_attribute` installed on the remote nodes, and we also need to specify the pacemaker node name when toggling the mode, as explained in https://bugzilla.suse.com/show_bug.cgi?id=983617#c14