### PR TITLE
drbd: Set node-id in resource config

### DIFF
--- a/chef/cookbooks/drbd/providers/resource.rb
+++ b/chef/cookbooks/drbd/providers/resource.rb
@@ -42,9 +42,11 @@ action :create do
       device: device,
       disk: disk,
       local_hostname: node.hostname,
+      local_node_id: node[:drbd][:local_node_id],
       local_ip: ip,
       port: port,
       remote_hostname: remote.hostname,
+      remote_node_id: node[:drbd][:remote_node_id],
       remote_ip: remote_ip
     )
     owner "root"

--- a/chef/cookbooks/drbd/templates/default/resource.erb
+++ b/chef/cookbooks/drbd/templates/default/resource.erb
@@ -5,9 +5,18 @@ resource <%= @resource %> {
   disk      <%= @disk %>;
   meta-disk internal;
   on <%= @local_hostname %> {
+    node-id   <%= @local_node_id %>;
     address   <%= @local_ip %>:<%= @port %>;
   }
   on <%= @remote_hostname %> {
+    node-id   <%= @remote_node_id %>;
     address   <%= @remote_ip %>:<%= @port %>;
+  }
+  connection {
+    host <%= @local_hostname %>  port <%= @port %>;
+    host <%= @remote_hostname %> port <%= @port %>;
+    net {
+      protocol C;
+    }
   }
 }

--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -387,6 +387,13 @@ class PacemakerService < ServiceObject
     role.default_attributes["drbd"]["common"]["net"] ||= {}
     role.default_attributes["drbd"]["common"]["net"]["shared_secret"] = \
       role.default_attributes["pacemaker"]["drbd"]["shared_secret"]
+    # set node IDs for drbd metadata
+    member_nodes.each do |member_node|
+      member_node[:drbd] ||= {}
+      member_node[:drbd][:local_node_id] = member_node[:pacemaker][:founder] ? 0 : 1
+      member_node[:drbd][:remote_node_id] = member_node[:pacemaker][:founder] ? 1 : 0
+      member_node.save
+    end
 
     # translate crowbar-specific stonith methods to proper attributes
     prepare_stonith_attributes(role.default_attributes["pacemaker"],


### PR DESCRIPTION
Some of the failing mkcloud HA tests (e.g. [1])) have the following chef
failure:

  Failure: (119) No valid meta-data signature found.

accompanied by an alert in the logs:

  ambiguous node id: meta-data: 0, config: 1

This patch sets the node IDs explicitly in the resource config file as
recommended in this mailing list post[2] and documented for drbd
9.0[3] to attempt to prevent these meta-data errors. It also adds a
connection stanza as that may also be affecting drbd's ability to
generate metadata[4]. Protocol C indicates "Writes to the DRBD device
complete as soon as they have reached the local and all remote disks"
and is the protocol used in the example configuration file in the
documentation. We could consider making this configurable later.

[1] https://ci.suse.de/job/openstack-mkcloud/56301/consoleText
[2] https://docs.linbit.com/doc/users-guide-90/re-drbdconf/
[3] http://lists.linbit.com/pipermail/drbd-dev/2017-January/003822.html
[4] http://lists.linbit.com/pipermail/drbd-dev/2017-January/003823.html