### PR TITLE
Write node's IP address into corosync.conf instead of subnet

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -26,6 +26,7 @@ if node[:corosync][:authkey].nil?
 end
 
 node[:corosync][:cluster_name] = CrowbarPacemakerHelper.cluster_name(node)
+node[:corosync][:bind_addr] = Barclamp::Inventory.get_network_by_type(node, "admin").address
 
 include_recipe "crowbar-pacemaker::quorum_policy"
 include_recipe "crowbar-pacemaker::stonith"

--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -363,7 +363,6 @@ class PacemakerService < ServiceObject
     admin_net = Chef::DataBag.load("crowbar/admin_network") rescue nil
 
     role.default_attributes["corosync"] ||= {}
-    role.default_attributes["corosync"]["bind_addr"] = admin_net["network"]["subnet"]
 
     role.default_attributes["corosync"]["mcast_addr"] = role.default_attributes["pacemaker"]["corosync"]["mcast_addr"]
     role.default_attributes["corosync"]["mcast_port"] = role.default_attributes["pacemaker"]["corosync"]["mcast_port"]


### PR DESCRIPTION
If there are more addresses in the subnet, corosync could get
confused and not find correct address to bind to.
So let's try to use node's IP instead (our corosync.conf files are node specific anyway)

See https://bugzilla.suse.com/show_bug.cgi?id=1030437 for context.


~~This is not tested.~~ UPDATE: tested already few times.

I know that in that bug mentioned above there's a patch for corosync proposed, but i was hoping to maybe have a simpler one on our side.