### PR TITLE
Write node's address into corosync.conf instead of subnet IP

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -26,6 +26,7 @@ if node[:corosync][:authkey].nil?
 end
 
 node[:corosync][:cluster_name] = CrowbarPacemakerHelper.cluster_name(node)
+node[:corosync][:bind_addr] = Barclamp::Inventory.get_network_by_type(node, "admin").address
 
 include_recipe "crowbar-pacemaker::quorum_policy"
 include_recipe "crowbar-pacemaker::stonith"

--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -25,8 +25,8 @@ if node[:corosync][:authkey].nil?
   include_recipe "crowbar-pacemaker::wait_for_founder"
 end
 
-node[:corosync][:cluster_name] = CrowbarPacemakerHelper.cluster_name(node)
-node[:corosync][:bind_addr] = Barclamp::Inventory.get_network_by_type(node, "admin").address
+node.normal[:corosync][:cluster_name] = CrowbarPacemakerHelper.cluster_name(node)
+node.normal[:corosync][:bind_addr] = Barclamp::Inventory.get_network_by_type(node, "admin").address
 
 include_recipe "crowbar-pacemaker::quorum_policy"
 include_recipe "crowbar-pacemaker::stonith"

--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -361,7 +361,6 @@ class PacemakerService < ServiceObject
     admin_net = founder.get_network_by_type("admin")
 
     role.default_attributes["corosync"] ||= {}
-    role.default_attributes["corosync"]["bind_addr"] = admin_net["subnet"]
 
     role.default_attributes["corosync"]["mcast_addr"] = role.default_attributes["pacemaker"]["corosync"]["mcast_addr"]
     role.default_attributes["corosync"]["mcast_port"] = role.default_attributes["pacemaker"]["corosync"]["mcast_port"]


### PR DESCRIPTION
If there are more addresses in the subnet, corosync could get
confused and not find correct address to bind to.
So let's try to use node's IP instead.

See bsc#1030437 for context.

(cherry picked from commit de1dfc6fc99570126c53128a3a66380ce9e59f5b)

Forward-port of https://github.com/crowbar/crowbar-ha/pull/189