### PR TITLE
Update .hound.suse.yml

### DIFF
--- a/.hound.suse.yml
+++ b/.hound.suse.yml
@@ -12,7 +12,7 @@
 
 Lint/EndAlignment:
   StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#lintendalignment
-  AlignWith: variable
+  EnforcedStyleAlignWith: variable
 
 Metrics/AbcSize:
   StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#metricsabcsize
@@ -57,17 +57,13 @@ Style/StringLiteralsInInterpolation:
   StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#stylestringliteralsininterpolation
   EnforcedStyle: double_quotes
 
-Style/SymbolArray:
-  StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#stylesymbolarray
-  EnforcedStyle: brackets
-
 Style/WordArray:
-  StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#stylewordarray
-  EnforcedStyle: brackets
+  StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#deviations-from-the-upstream-style-guide
+  Enabled: false
 
 Style/RegexpLiteral:
-  StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#styleregexpliteral
-  EnforcedStyle: slashes
+  StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#deviations-from-the-upstream-style-guide
+  Enabled: false
 
 Style/SignalException:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#fail-method


### PR DESCRIPTION
Get new version from:
https://github.com/SUSE/style-guides/blob/master/rubocop-suse.yml
This will fix RuboCop error:
Error: obsolete parameter AlignWith (for Lint/EndAlignment)
found in crowbar-ha/.hound.suse.yml `AlignWith` has been renamed
to `EnforcedStyleAlignWith`.