### PR TITLE
HAProxy: Extend configuration options

### DIFF
--- a/chef/cookbooks/haproxy/resources/loadbalancer.rb
+++ b/chef/cookbooks/haproxy/resources/loadbalancer.rb
@@ -20,14 +20,22 @@
 actions :create, :delete
 default_action :create
 
-attribute :name,    kind_of: String,  name_attribute: true
-attribute :type,    kind_of: String,  default: "listen", equal_to: ["listen", "backend", "frontend"]
-attribute :address, kind_of: String,  default: "0.0.0.0"
-attribute :port,    kind_of: Integer, default: 0
-attribute :mode,    kind_of: String,  default: "http", equal_to: ["http", "tcp", "health"]
-attribute :balance, kind_of: String,  default: "",
-          equal_to: ["", "roundrobin", "static-rr", "leastconn", "first", "source"]
-attribute :use_ssl, kind_of: [TrueClass, FalseClass], default: false
-attribute :stick,   kind_of: Hash,    default: {}
-attribute :options, kind_of: Array,   default: []
-attribute :servers, kind_of: Array,   default: []
+attribute :name,            kind_of: String,  name_attribute: true
+attribute :type,            kind_of: String,  default: "listen", equal_to: [
+  "listen", "backend", "frontend"
+]
+attribute :address,         kind_of: String,  default: "0.0.0.0"
+attribute :port,            kind_of: Integer, default: 0
+attribute :mode,            kind_of: String,  default: "http", equal_to: [
+  "http", "tcp", "health"
+]
+attribute :balance,         kind_of: String,  default: "", equal_to: [
+  "", "roundrobin", "static-rr", "leastconn", "first", "source"
+]
+attribute :use_ssl,         kind_of: [TrueClass, FalseClass], default: false
+attribute :stick,           kind_of: Hash,    default: {}
+attribute :options,         kind_of: Array,   default: []
+attribute :acls,            kind_of: Array,   default: []
+attribute :use_backends,    kind_of: Array,   default: []
+attribute :default_backend, kind_of: String,  default: ""
+attribute :servers,         kind_of: Array,   default: []

--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -39,7 +39,9 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
   <% node[:haproxy][:sections][type].keys.sort.each do |name| -%>
     <% content = node[:haproxy][:sections][type][name] -%>
 <%= type %> <%= name %>
+    <% unless content[:address].nil? || content[:port].nil? -%>
     bind <%= content[:address] %>:<%= content[:port] %>
+    <% end -%>
 	mode <%= content[:mode] %>
     <% unless content[:balance].nil? -%>
 	balance <%= content[:balance] %>
@@ -85,6 +87,16 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
 
     <% content[:options].each do |option| -%>
 	option <%= option %>
+    <% end -%>
+
+    <% content[:acls].each do |acl| -%>
+	acl <%= acl %>
+    <% end -%>
+    <% content[:use_backends].each do |use_backend| -%>
+	use_backend <%= use_backend %>
+    <% end -%>
+    <% unless content[:default_backend].empty? -%>
+	default_backend <%= content[:default_backend] %>
     <% end -%>
 
     <% content[:servers].each do |server| -%>


### PR DESCRIPTION
We configure Monasca using the ansible-based `monasca-installer`, which is run from Crowbar. This means that the Monasca API services we want to put behind `haproxy` are not directly under Crowbar's aegis. To put them behind Crowbar-managed `haproxy` instances we need these new options.