### PR TITLE
pacemaker: Add monitoring network support

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/helpers.rb
@@ -120,7 +120,7 @@ module CrowbarPacemakerHelper
     return nil unless cluster_enabled?(node)
     # only support this for admin & public; it's not needed elsewhere, and
     # saves us some checks
-    return nil unless ["admin", "public"].include? net
+    return nil unless ["admin", "public", "monitoring"].include? net
 
     vhostname = cluster_vhostname(node) if vhostname.nil?
 

--- a/chef/data_bags/crowbar/template-pacemaker.json
+++ b/chef/data_bags/crowbar/template-pacemaker.json
@@ -46,7 +46,8 @@
       },
       "haproxy": {
         "admin_name": "",
-        "public_name": ""
+        "public_name": "",
+        "monitoring_name": ""
       }
     }
   },
@@ -76,4 +77,3 @@
     }
   }
 }
-

--- a/chef/data_bags/crowbar/template-pacemaker.schema
+++ b/chef/data_bags/crowbar/template-pacemaker.schema
@@ -126,7 +126,8 @@
               "required": true,
               "mapping": {
                 "admin_name": { "type": "str", "required": true },
-                "public_name": { "type": "str", "required": true }
+                "public_name": { "type": "str", "required": true },
+                "monitoring_name": { "type": "str", "required": true }
               }
             }
           }

--- a/crowbar_framework/app/models/pacemaker_service_object.rb
+++ b/crowbar_framework/app/models/pacemaker_service_object.rb
@@ -162,7 +162,7 @@ class PacemakerServiceObject < ServiceObject
     def vhostname_to_vip(vhostname, net)
       # only support this for admin & public; it's not needed elsewhere, and
       # saves us some checks
-      return nil unless ["admin", "public"].include? net
+      return nil unless ["admin", "public", "monitoring"].include? net
 
       net_db = Chef::DataBagItem.load("crowbar", "#{net}_network").raw_data
       net_db["allocated_by_name"][vhostname]["address"]


### PR DESCRIPTION
Monitoring network is used by Monasca for sending logs and metrics.
Pacemaker need to be able to get this network VIP so it needs to know
that such network exists.

https://github.com/crowbar/crowbar-core/pull/1064