### PR TITLE
pacemaker: Use discovered BMC addr (bsc#1035215)

### DIFF
--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -754,7 +754,12 @@ class PacemakerService < ServiceObject
 
         params = {}
         params["hostname"] = stonith_node_name
-        params["ipaddr"] = bmc_net["address"]
+        # If the bmc is using dhcp, we can't trust the crowbar bmc network to know it
+        params["ipaddr"] = if cluster_node["ipmi"]["use_dhcp"]
+          cluster_node["crowbar_wall"]["ipmi"]["address"]
+        else
+          bmc_net["address"]
+        end
         params["userid"] = cluster_node["ipmi"]["bmc_user"]
         params["passwd"] = cluster_node["ipmi"]["bmc_password"]
 


### PR DESCRIPTION
In the IPMI barclamp, use_dhcp is set to true,
ignore_address_suggestions is irrelevant and the barclamp must use the
address discovered from the BMC interfaces. Since we're relying on dhcp
for this, we can't trust our database of allocated IPs to give us the
right address. This can cause the address for the STONITH device to be
either unset or incorrect, even when the IPMI barclamp reports the
correct BMC address. This patch looks up the use_dhcp value for the node
and, if set to true, uses the discovered address stored in the node
rather than the address allocated in the BMC network hash.