### PR TITLE
[3.0] pacemaker: Use discovered BMC addr (bsc#1035215)

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/stonith.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/stonith.rb
@@ -111,7 +111,13 @@ when "ipmi_barclamp"
 
     params = {}
     params["hostname"] = stonith_node_name
-    params["ipaddr"] = cluster_node[:crowbar][:network][:bmc][:address]
+    # If the bmc is using dhcp, we can't trust the crowbar bmc network to know it
+    params["ipaddr"] = if cluster_node[:ipmi][:use_dhcp]
+      cluster_node[:crowbar_wall][:ipmi][:address]
+    else
+      cluster_node[:crowbar][:network][:bmc][:address]
+    end
+
     params["userid"] = cluster_node[:ipmi][:bmc_user]
     params["passwd"] = cluster_node[:ipmi][:bmc_password]
 


### PR DESCRIPTION
In the IPMI barclamp, use_dhcp is set to true,
ignore_address_suggestions is irrelevant and the barclamp must use the
address discovered from the BMC interfaces. Since we're relying on dhcp
for this, we can't trust our database of allocated IPs to give us the
right address. This can cause the address for the STONITH device to be
either unset or incorrect, even when the IPMI barclamp reports the
correct BMC address. This patch looks up the use_dhcp value for the node
and, if set to true, uses the discovered address stored in the node
rather than the address allocated in the BMC network hash.

Note that this is not a direct cherry-pick, as the logic moved from the chef
recipe to the crowbar model between SOC6 and SOC7.