### PR TITLE
pacemaker: Use bmc_interface for IPMI (bsc#1046567)

### DIFF
--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -757,6 +757,7 @@ class PacemakerService < ServiceObject
         params["ipaddr"] = bmc_net["address"]
         params["userid"] = cluster_node["ipmi"]["bmc_user"]
         params["passwd"] = cluster_node["ipmi"]["bmc_password"]
+        params["interface"] = cluster_node["ipmi"]["bmc_interface"]
 
         stonith_attributes["per_node"]["nodes"][stonith_node_name] ||= {}
         stonith_attributes["per_node"]["nodes"][stonith_node_name]["params"] = params


### PR DESCRIPTION
Also pass in the defined bmc_interface when configuring IPMI. Requires
crowbar-core #1260.

Co-Authored-By: Eugen Block <e.block@suse.com>