### PR TITLE
haproxy: remove not working check-ssl option (bsc#1045783 bsc#1046093)

### DIFF
--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -52,11 +52,7 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
     <% end -%>
 
     <% content[:servers].each do |server| -%>
-      <% if content[:use_ssl] -%>
-	server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check-ssl verify none inter 2000 rise 2 fall 5
-      <% else -%>
-	server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check inter 2000 rise 2 fall 5
-      <% end -%>
+	server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check verify none inter 2000 rise 2 fall 5
     <% end -%>
 
   <% end -%>


### PR DESCRIPTION
The check-ssl option does not seem to work properly as reported on
the mentioned bugs. Changing to the normal check option and leaving the ssl
check to the ssl-hello-chk option seems to make the checks work properly.


Tested extensively with different barclamps, options and ssl configs, this seems to work as expected for both SSL endpoints and normal ones.
