### PR TITLE
[4.0] Rework haproxy config for stickiness and balance strategy

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/haproxy.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/haproxy.rb
@@ -20,11 +20,6 @@
 #FIXME: delete group when it's not needed anymore
 #FIXME: need to find/write OCF for haproxy
 
-# Recommendation from the OpenStack HA guide is to use "source" as balance
-# algorithm. This obviously is less useful for load balancing, but we care more
-# about HA and things working than about load balancing.
-node.default["haproxy"]["defaults"]["balance"] = "source"
-
 # With the default bufsize, getting a keystone PKI token from its ID doesn't
 # work, because the URI path is too long for haproxy
 node.default["haproxy"]["global"]["bufsize"] = 32768

--- a/chef/cookbooks/haproxy/providers/loadbalancer.rb
+++ b/chef/cookbooks/haproxy/providers/loadbalancer.rb
@@ -47,6 +47,9 @@ action :create do
   else
     section["mode"] = new_resource.mode
   end
+  unless new_resource.balance.empty?
+    section["balance"] = new_resource.balance
+  end
 
   section["stick"] = new_resource.stick
   section["stick"]["expire"] ||= "30m"

--- a/chef/cookbooks/haproxy/providers/loadbalancer.rb
+++ b/chef/cookbooks/haproxy/providers/loadbalancer.rb
@@ -47,9 +47,7 @@ action :create do
   else
     section["mode"] = new_resource.mode
   end
-  unless new_resource.balance.empty?
-    section["balance"] = new_resource.balance
-  end
+  section["balance"] = new_resource.balance unless new_resource.balance.empty?
 
   section["stick"] = new_resource.stick
   section["stick"]["expire"] ||= "30m"

--- a/chef/cookbooks/haproxy/providers/loadbalancer.rb
+++ b/chef/cookbooks/haproxy/providers/loadbalancer.rb
@@ -47,6 +47,10 @@ action :create do
   else
     section["mode"] = new_resource.mode
   end
+
+  section["stick"] = new_resource.stick
+  section["stick"]["expire"] ||= "30m"
+
   section["options"] = new_resource.options || []
   if section["options"].empty? || section["options"].include?("defaults")
     section["options"].delete("defaults")

--- a/chef/cookbooks/haproxy/resources/loadbalancer.rb
+++ b/chef/cookbooks/haproxy/resources/loadbalancer.rb
@@ -26,5 +26,6 @@ attribute :address, kind_of: String,  default: "0.0.0.0"
 attribute :port,    kind_of: Integer, default: 0
 attribute :mode,    kind_of: String,  default: "http", equal_to: ["http", "tcp", "health"]
 attribute :use_ssl, kind_of: [TrueClass, FalseClass], default: false
+attribute :stick,   kind_of: Hash,    default: {}
 attribute :options, kind_of: Array,   default: []
 attribute :servers, kind_of: Array,   default: []

--- a/chef/cookbooks/haproxy/resources/loadbalancer.rb
+++ b/chef/cookbooks/haproxy/resources/loadbalancer.rb
@@ -25,6 +25,7 @@ attribute :type,    kind_of: String,  default: "listen", equal_to: ["listen", "b
 attribute :address, kind_of: String,  default: "0.0.0.0"
 attribute :port,    kind_of: Integer, default: 0
 attribute :mode,    kind_of: String,  default: "http", equal_to: ["http", "tcp", "health"]
+attribute :balance, kind_of: String,  default: "", equal_to: ["", "roundrobin", "static-rr", "leastconn", "first", "source"]
 attribute :use_ssl, kind_of: [TrueClass, FalseClass], default: false
 attribute :stick,   kind_of: Hash,    default: {}
 attribute :options, kind_of: Array,   default: []

--- a/chef/cookbooks/haproxy/resources/loadbalancer.rb
+++ b/chef/cookbooks/haproxy/resources/loadbalancer.rb
@@ -25,7 +25,8 @@ attribute :type,    kind_of: String,  default: "listen", equal_to: ["listen", "b
 attribute :address, kind_of: String,  default: "0.0.0.0"
 attribute :port,    kind_of: Integer, default: 0
 attribute :mode,    kind_of: String,  default: "http", equal_to: ["http", "tcp", "health"]
-attribute :balance, kind_of: String,  default: "", equal_to: ["", "roundrobin", "static-rr", "leastconn", "first", "source"]
+attribute :balance, kind_of: String,  default: "",
+          equal_to: ["", "roundrobin", "static-rr", "leastconn", "first", "source"]
 attribute :use_ssl, kind_of: [TrueClass, FalseClass], default: false
 attribute :stick,   kind_of: Hash,    default: {}
 attribute :options, kind_of: Array,   default: []

--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -64,7 +64,8 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
 
 	# Learn on response if server hello.
 	stick store-response payload_lv(43,1) if serverhello
-    <% elsif content[:mode] == "http" && content[:stick] && content[:stick][:cookie]
+    <% elsif content[:mode] == "http" && content[:stick] &&
+         content[:stick][:cookies] && !content[:stick][:cookies].empty?
        # There are various options here, described in:
        # http://stackoverflow.com/questions/27094501/haproxy-1-5-8-how-do-i-configure-cookie-based-stickiness
        # We go with the stick-table to avoid no-cache and exposing backends
@@ -73,8 +74,10 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
        # http://serverfault.com/questions/550910/haproxy-appsession-vs-cookie-precedence
         -%>
 	stick-table type string len 64 size 100k expire <%= content[:stick][:expire] %>
-	stick store-response res.cook(<%= content[:stick][:cookie] %>)
-	stick match req.cook(<%= content[:stick][:cookie] %>)
+      <% content[:stick][:cookies].each do |cookie| -%>
+	stick store-response res.cook(<%= cookie %>)
+	stick match req.cook(<%= cookie %>)
+      <% end -%>
     <% end -%>
 
     <% content[:options].each do |option| -%>

--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -40,9 +40,30 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
     <% content = node[:haproxy][:sections][type][name] -%>
 <%= type %> <%= name %>
     bind <%= content[:address] %>:<%= content[:port] %>
-    <% if content[:use_ssl] -%>
-       mode tcp
-       balance source
+    <% if content[:use_ssl] # http://blog.exceliance.fr/2011/07/04/maintain-affinity-based-on-ssl-session-id/ -%>
+	mode tcp
+
+	# maximum SSL session ID length is 32 bytes.
+	stick-table type binary len 32 size 30k expire 30m
+
+	acl clienthello req_ssl_hello_type 1
+	acl serverhello rep_ssl_hello_type 2
+
+	# use tcp content accepts to detects ssl client and server hello.
+	tcp-request inspect-delay 5s
+	tcp-request content accept if clienthello
+
+	# no timeout on response inspect delay by default.
+	tcp-response content accept if serverhello
+
+	# SSL session ID (SSLID) may be present on a client or server hello.
+	# Its length is coded on 1 byte at offset 43 and its value starts
+	# at offset 44.
+	# Match and learn on request if client hello.
+	stick on payload_lv(43,1) if clienthello
+
+	# Learn on response if server hello.
+	stick store-response payload_lv(43,1) if serverhello
     <% else -%>
 	mode <%= content[:mode] %>
     <% end -%>

--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -45,7 +45,7 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
 	balance <%= content[:balance] %>
     <% end -%>
 
-    <% if content[:use_ssl] # http://blog.exceliance.fr/2011/07/04/maintain-affinity-based-on-ssl-session-id/ -%>
+    <% if content[:use_ssl] # http://www.haproxy.com/blog/maintain-affinity-based-on-ssl-session-id/ -%>
 	# maximum SSL session ID length is 32 bytes.
 	stick-table type binary len 32 size 30k expire <%= content[:stick][:expire] %>
 

--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -44,7 +44,7 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
 
     <% if content[:use_ssl] # http://blog.exceliance.fr/2011/07/04/maintain-affinity-based-on-ssl-session-id/ -%>
 	# maximum SSL session ID length is 32 bytes.
-	stick-table type binary len 32 size 30k expire 30m
+	stick-table type binary len 32 size 30k expire <%= content[:stick][:expire] %>
 
 	acl clienthello req_ssl_hello_type 1
 	acl serverhello rep_ssl_hello_type 2
@@ -64,6 +64,17 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
 
 	# Learn on response if server hello.
 	stick store-response payload_lv(43,1) if serverhello
+    <% elsif content[:mode] == "http" && content[:stick] && content[:stick][:cookie]
+       # There are various options here, described in:
+       # http://stackoverflow.com/questions/27094501/haproxy-1-5-8-how-do-i-configure-cookie-based-stickiness
+       # We go with the stick-table to avoid no-cache and exposing backends
+       # through cookies.
+       # Note that appsession is easier, but deprecated:
+       # http://serverfault.com/questions/550910/haproxy-appsession-vs-cookie-precedence
+        -%>
+	stick-table type string len 64 size 100k expire <%= content[:stick][:expire] %>
+	stick store-response res.cook(<%= content[:stick][:cookie] %>)
+	stick match req.cook(<%= content[:stick][:cookie] %>)
     <% end -%>
 
     <% content[:options].each do |option| -%>

--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -41,6 +41,9 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
 <%= type %> <%= name %>
     bind <%= content[:address] %>:<%= content[:port] %>
 	mode <%= content[:mode] %>
+    <% unless content[:balance].nil? -%>
+	balance <%= content[:balance] %>
+    <% end -%>
 
     <% if content[:use_ssl] # http://blog.exceliance.fr/2011/07/04/maintain-affinity-based-on-ssl-session-id/ -%>
 	# maximum SSL session ID length is 32 bytes.

--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -40,9 +40,9 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
     <% content = node[:haproxy][:sections][type][name] -%>
 <%= type %> <%= name %>
     bind <%= content[:address] %>:<%= content[:port] %>
-    <% if content[:use_ssl] # http://blog.exceliance.fr/2011/07/04/maintain-affinity-based-on-ssl-session-id/ -%>
-	mode tcp
+	mode <%= content[:mode] %>
 
+    <% if content[:use_ssl] # http://blog.exceliance.fr/2011/07/04/maintain-affinity-based-on-ssl-session-id/ -%>
 	# maximum SSL session ID length is 32 bytes.
 	stick-table type binary len 32 size 30k expire 30m
 
@@ -64,8 +64,6 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
 
 	# Learn on response if server hello.
 	stick store-response payload_lv(43,1) if serverhello
-    <% else -%>
-	mode <%= content[:mode] %>
     <% end -%>
 
     <% content[:options].each do |option| -%>


### PR DESCRIPTION
This is the backport of #208

We enable stickiness based on SSL sessions
We add the ability to do stickiness based on cookies
We allow to define the balance strategy on a per-resource basis
We stop overriding the default balance strategy (and therefore use roundrobin by default)