### PR TITLE
[4.0] drbd: Remove deprecated option for initial DRBD sync

### DIFF
--- a/chef/cookbooks/drbd/providers/resource.rb
+++ b/chef/cookbooks/drbd/providers/resource.rb
@@ -70,7 +70,7 @@ action :create do
   drbdadm_up.run_action(:run)
 
   # claim primary based off of master
-  execute "drbdadm -- --overwrite-data-of-peer primary #{name}" do
+  execute "drbdadm primary --force #{name}" do
     only_if { drbd_resource_template.updated_by_last_action? && master }
     action :nothing
   end.run_action(:run)


### PR DESCRIPTION
DRBD manual says "--force option replaces --overwrite-data-of-peer".
Although it was deprecated in 8.4 already, drbd startup started failing
only now when we switched to SLES12SP3.

(cherry picked from commit e30972d339528cc56240a46315b84b8c103aa831)