### PR TITLE
service_object: Use rails logger directly

### DIFF
--- a/chef/data_bags/crowbar/migrate/pacemaker/100_stonith_in_rails.rb
+++ b/chef/data_bags/crowbar/migrate/pacemaker/100_stonith_in_rails.rb
@@ -11,7 +11,7 @@ def upgrade(ta, td, a, d)
   remotes = d["elements"]["pacemaker-remote"] || []
   remote_nodes = remotes.map { |n| NodeObject.find_node_by_name n }
 
-  service = PacemakerService.new Rails.logger
+  service = PacemakerService.new
   service.prepare_stonith_attributes(a, remote_nodes, member_nodes, remotes, members)
 
   return a, d

--- a/crowbar_framework/app/controllers/pacemaker_controller.rb
+++ b/crowbar_framework/app/controllers/pacemaker_controller.rb
@@ -19,7 +19,6 @@ class PacemakerController < BarclampController
   protected
 
   def initialize_service
-    @service_object = PacemakerService.new logger
+    @service_object = PacemakerService.new
   end
 end
-

--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -17,7 +17,7 @@
 
 class PacemakerService < ServiceObject
   def initialize(thelogger = nil)
-    super(Rails.logger)
+    super
     @bc_name = "pacemaker"
   end
 


### PR DESCRIPTION
This commit continues the work which was done in
https://github.com/crowbar/crowbar-core/pull/1025. Which means we don't
have to pass the logger anymore.