### PR TITLE
Add a support to use 'backup' option in server line.

### DIFF
--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -82,16 +82,20 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
 	stick match req.cook(<%= cookie %>)
       <% end -%>
     <% end -%>
-
+    <% if content[:stick][:on] -%>
+        stick-table type ip size 1
+        stick on <%= content[:stick][:on] %>
+    <% end -%>
     <% content[:options].each do |option| -%>
 	option <%= option %>
     <% end -%>
 
     <% content[:servers].each do |server| -%>
+      <% backup = server[:backup] ? "backup" : "" %>
       <% if content[:use_ssl] -%>
-	server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check check-ssl verify none inter 2000 rise 2 fall 5
+	server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check check-ssl verify none inter 2000 rise 2 fall 5 <%= backup %>
       <% else -%>
-	server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check inter 2000 rise 2 fall 5
+	server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check inter 2000 rise 2 fall 5 <%= backup %>
       <% end -%>
     <% end -%>
 


### PR DESCRIPTION
'backup' means that given server is only used in load
balancing when all other non-backup servers are unavailable.

We might need a setup (e.g. with mariadb cluster) where we want
to prevent existence of multiple servers being accessed at the same time.