### PR TITLE
Let cluster_vhostname find correct name for database clusters.

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/helpers.rb
@@ -77,7 +77,12 @@ module CrowbarPacemakerHelper
     # substitute one with the other
     # Similar code is in the barclamp side:
     # allocate_virtual_ips_for_cluster_in_networks
-    "cluster-#{cluster_name(node)}".gsub("_", "-")
+    # However, database cluster has different name scheme.
+    if node[:database][:ha][:enabled]
+      "database-default-#{cluster_name(node)}"
+    else
+      "cluster-#{cluster_name(node)}".tr("_", "-")
+    end
   end
 
   # The virtual admin name for the cluster is a name picked by the operator as


### PR DESCRIPTION
database cluster has different name scheme and we might need it
to configure with HAProxy (haproxy code uses cluster_vhostname).

This may be totally wrong approach, I know...