### PR TITLE
[stable/4.0] Add a support to use 'backup' option in server line.

### DIFF
--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -82,16 +82,20 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
 	stick match req.cook(<%= cookie %>)
       <% end -%>
     <% end -%>
-
+    <% if content[:stick][:on] -%>
+        stick-table type ip size 1
+        stick on <%= content[:stick][:on] %>
+    <% end -%>
     <% content[:options].each do |option| -%>
 	option <%= option %>
     <% end -%>
 
     <% content[:servers].each do |server| -%>
+      <% backup = server[:backup] ? "backup" : "" %>
       <% if content[:use_ssl] -%>
-	server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check check-ssl verify none inter 2000 rise 2 fall 5
+	server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check check-ssl verify none inter 2000 rise 2 fall 5 <%= backup %>
       <% else -%>
-	server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check inter 2000 rise 2 fall 5
+	server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check inter 2000 rise 2 fall 5 <%= backup %>
       <% end -%>
     <% end -%>
 


### PR DESCRIPTION
'backup' means that given server is only used in load
balancing when all other non-backup servers are unavailable.

'stick on dst' should make sure that destination server is not
left even if it is backup one and non-backup is healthy again.
This should prevent additional disruption once the failing node
is back and running.

We might need a setup (e.g. with mariadb cluster) where we want
to prevent existence of multiple servers being accessed at the same time.

(cherry picked from commit c1cf765bb38932ed5747e749ebf5341846094dd7)

Backport of https://github.com/crowbar/crowbar-ha/pull/215