### PR TITLE
Allow configuration of more options for server lines.

### DIFF
--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -91,11 +91,12 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
     <% end -%>
 
     <% content[:servers].each do |server| -%>
-      <% backup = server[:backup] ? "backup" : "" %>
+      <% backup = server[:backup] ? " backup" : "" %>
+      <% fastinter = server[:fastinter] ? " fastinter #{server[:fastinter]}" : "" %>
       <% if content[:use_ssl] -%>
-	server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check check-ssl verify none inter 2000 rise 2 fall 5 <%= backup %>
+	server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check check-ssl verify none inter <%= server[:inter] || 2000 %><%= fastinter %> rise <%= server[:rise] || 2 %> fall <%= server[:fall] || 5 %><%= backup %>
       <% else -%>
-	server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check inter 2000 rise 2 fall 5 <%= backup %>
+	server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check inter <%= server[:inter] || 2000 %><%= fastinter %> rise <%= server[:rise] || 2 %> fall <%= server[:fall] || 5 %><%= backup %>
       <% end -%>
     <% end -%>
 


### PR DESCRIPTION
fastinter/rise/fall values influence haproxy monitoring behavior.
See e.g. https://www.digitalocean.com/community/tutorials/how-to-use-haproxy-to-set-up-mysql-load-balancing--3