### PR TITLE
A quick tidy up of haproxy server options

### DIFF
--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -91,13 +91,15 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
     <% end -%>
 
     <% content[:servers].each do |server| -%>
-      <% backup = server[:backup] ? " backup" : "" %>
-      <% fastinter = server[:fastinter] ? " fastinter #{server[:fastinter]}" : "" %>
-      <% if content[:use_ssl] -%>
-	server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check check-ssl verify none inter <%= server[:inter] || 2000 %><%= fastinter %> rise <%= server[:rise] || 2 %> fall <%= server[:fall] || 5 %><%= backup %>
-      <% else -%>
-	server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check inter <%= server[:inter] || 2000 %><%= fastinter %> rise <%= server[:rise] || 2 %> fall <%= server[:fall] || 5 %><%= backup %>
-      <% end -%>
+      <%
+        ssl = content[:use_ssl] ? " check-ssl verify none" : ""
+        inter = " inter #{server[:inter] || 2000}"
+        fastinter = server[:fastinter] ? " fastinter #{server[:fastinter]}" : ""
+        rise = " rise #{server[:rise] || 2}"
+        fall = " fall #{server[:fall] || 5}"
+        backup = server[:backup] ? " backup" : ""
+      %>
+        server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check<%= ssl %><%= inter %><%= fastinter %><%= rise %><%= fall %><%= backup %>
     <% end -%>
 
   <% end -%>


### PR DESCRIPTION
Following on from PR #220, improve the code readability of the server
options. This change places the logic in a clear position before
spitting it out into the server line.