### PR TITLE
crowbar-pacemaker: Allow overriding start/stop commands for crm_resource

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/providers/service.rb
+++ b/chef/cookbooks/crowbar-pacemaker/providers/service.rb
@@ -179,15 +179,17 @@ action :restart do
   use_crm_resource = new_resource.supports[:restart_crm_resource]
   no_maintenance_mode = new_resource.supports[:no_crm_maintenance_mode]
   pacemaker_resource = new_resource.supports[:pacemaker_resource_name] || service_name
+  resource_stop_cmd = new_resource.supports[:crm_resource_stop_cmd] || "force-stop"
+  resource_start_cmd = new_resource.supports[:crm_resource_start_cmd] || "force-start"
 
   if service_is_running?(service_name, use_crm_resource, pacemaker_resource)
     set_maintenance_mode unless no_maintenance_mode
 
     if use_crm_resource
-      bash "crm_resource --force-stop / --force-start  --resource #{pacemaker_resource}" do
+      bash "crm_resource --#{resource_stop_cmd} / --#{resource_start_cmd}  --resource #{pacemaker_resource}" do
         code <<-EOH
-          crm_resource --force-stop --resource #{pacemaker_resource} && \
-          crm_resource --force-start --resource #{pacemaker_resource}
+          crm_resource --#{resource_stop_cmd} --resource #{pacemaker_resource} && \
+          crm_resource --#{resource_start_cmd} --resource #{pacemaker_resource}
           EOH
         action :nothing
       end.run_action(:run)

--- a/chef/cookbooks/crowbar-pacemaker/providers/service.rb
+++ b/chef/cookbooks/crowbar-pacemaker/providers/service.rb
@@ -221,10 +221,14 @@ end
 def service_is_running?(name, use_crm_resource, pacemaker_resource)
   if use_crm_resource
     `crm_resource --force-check --resource #{pacemaker_resource}`
+    # For Master/Slave resources "monitor" will return OCF_RUNNING_MASTER (8)
+    # on nodes that are running the resource in Master role currently. We need
+    # to treat that as a successfully result as well.
+    $?.success? || $?.exitstatus == 8
   else
     `service #{name} status`
+    $?.success?
   end
-  $?.success?
 end
 
 def proxy_action(resource, service_action)


### PR DESCRIPTION
The 1st commit is just a pretty simple fix for `service_is_running?` to make it work with Master/Slave resources.

The 2nd commit enhances the pacemaker "service" provider to allow passing in alternative start/stop commands when used with the "restart_crm_resource" flag. We need this for the galera resource agent. In order to restart mysql on a single node we need to get the resource though a demote/promote cycle once (instead of start/stop). See e.g. https://github.com/jhesketh/crowbar-openstack/commit/ce00239fe10848b591a561a16d28a43d7f68a5a7 for the current work in progress.