### PR TITLE
set default bmc_interface to lanplus

### DIFF
--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -762,7 +762,7 @@ class PacemakerService < ServiceObject
         end
         params["userid"] = cluster_node["ipmi"]["bmc_user"]
         params["passwd"] = cluster_node["ipmi"]["bmc_password"]
-        params["interface"] = cluster_node["ipmi"]["bmc_interface"]
+        params["interface"] = cluster_node["ipmi"]["bmc_interface"] || "lanplus"
 
         stonith_attributes["per_node"]["nodes"][stonith_node_name] ||= {}
         stonith_attributes["per_node"]["nodes"][stonith_node_name]["params"] = params


### PR DESCRIPTION
The stonith agent external/ipmi requires an interface to work.
The model is reading bmc_interface from the node's ipmi attributes,
but there is no such attribute stored/set on the node.
To circumvent, we default to "lanplus", which makes the stonith ipmi
resource work properly.