### PR TITLE
Increase pacemaker timeout to 120 (bsc#1056473)

### DIFF
--- a/chef/cookbooks/pacemaker/attributes/default.rb
+++ b/chef/cookbooks/pacemaker/attributes/default.rb
@@ -52,7 +52,9 @@ default[:pacemaker][:founder] = nil
 default[:pacemaker][:is_remote] = false
 default[:pacemaker][:crm][:initial_config_file] = "/etc/corosync/crm-initial.conf"
 default[:pacemaker][:crm][:no_quorum_policy] = "ignore"
-default[:pacemaker][:crm][:op_default_timeout] = 60
+# Should be longer than the systemd timeouts (defaults to 90s) so that
+# pacemaker only reacts when systemd is not helping anymore
+default[:pacemaker][:crm][:op_default_timeout] = 120
 default[:pacemaker][:crm][:migration_threshold] = 3
 
 # acceptable CIB syntax version; if lower is detected, we must force its upgrade


### PR DESCRIPTION
to make it longer than the 90s that systemd is waiting
before it sends a SIGKILL to a stuck service.

This can help to avoid needless random fencing of nodes during shutdown/reboot
https://bugzilla.suse.com/show_bug.cgi?id=1056473