### PR TITLE
haproxy: provide a option to ratelimit frontends

### DIFF
--- a/chef/cookbooks/haproxy/attributes/default.rb
+++ b/chef/cookbooks/haproxy/attributes/default.rb
@@ -21,6 +21,7 @@ default[:haproxy][:platform][:package] = "haproxy"
 default[:haproxy][:platform][:user] = "haproxy"
 default[:haproxy][:platform][:group] = "haproxy"
 default[:haproxy][:platform][:config_file] = "/etc/haproxy/haproxy.cfg"
+default[:haproxy][:platform][:error_dir] = "/etc/haproxy/errorfiles"
 
 default[:haproxy][:global][:maxconn] = 4096
 default[:haproxy][:global][:bufsize] = 16384

--- a/chef/cookbooks/haproxy/files/default/429.http
+++ b/chef/cookbooks/haproxy/files/default/429.http
@@ -1,0 +1,7 @@
+HTTP/1.1 429 Too Many Requests
+Cache-Control: no-cache
+Connection: close
+Content-Type: text/plain
+Retry-After: 60
+
+Too Many Requests (HAP429).\r\n

--- a/chef/cookbooks/haproxy/providers/loadbalancer.rb
+++ b/chef/cookbooks/haproxy/providers/loadbalancer.rb
@@ -63,6 +63,10 @@ action :create do
   end
   section["servers"] = new_resource.servers
 
+  if new_resource.rate_limit && new_resource.rate_limit.to_i != 0
+    section["rate_limit"] = new_resource.rate_limit
+  end
+
   node["haproxy"]["sections"][new_resource.type] ||= {}
   node["haproxy"]["sections"][new_resource.type][new_resource.name] = section
 end

--- a/chef/cookbooks/haproxy/recipes/setup.rb
+++ b/chef/cookbooks/haproxy/recipes/setup.rb
@@ -24,4 +24,30 @@ template node[:haproxy][:platform][:config_file] do
   owner "root"
   group "root"
   mode 00644
+  variables(
+    lazy {
+      {
+        rate_limit_enabled: node[:haproxy][:sections].keys.each.any? {
+            |type| node[:haproxy][:sections][type].any? {
+              |service, values| !values["rate_limit"].nil? && !values["rate_limit"].to_i.zero?
+          }
+        }
+      }
+    }
+  )
+end
+
+directory node[:haproxy][:platform][:error_dir] do
+  action :create
+  owner "root"
+  group "root"
+  mode 0o644
+end
+
+cookbook_file "#{node[:haproxy][:platform][:error_dir]}/429.http" do
+  source "429.http"
+  action :create
+  owner "root"
+  group "root"
+  mode 0o644
 end

--- a/chef/cookbooks/haproxy/resources/loadbalancer.rb
+++ b/chef/cookbooks/haproxy/resources/loadbalancer.rb
@@ -31,3 +31,4 @@ attribute :use_ssl, kind_of: [TrueClass, FalseClass], default: false
 attribute :stick,   kind_of: Hash,    default: {}
 attribute :options, kind_of: Array,   default: []
 attribute :servers, kind_of: Array,   default: []
+attribute :rate_limit, kind_of: Integer, default: nil

--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -101,6 +101,25 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
       %>
         server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check<%= ssl %><%= inter %><%= fastinter %><%= rise %><%= fall %><%= backup %>
     <% end -%>
+	<% unless content[:rate_limit].nil? || content[:rate_limit].to_i.zero? -%>
+	# Rate limiting config options
+	tcp-request inspect-delay 5s
+	acl too_many_reqs_by_user sc0_gpc0_rate() gt <%= content[:rate_limit] %>
+	acl mark_seen sc0_inc_gpc0 gt 0
+	stick-table type string size 100k expire 60s store gpc0_rate(60s)
+	tcp-request content track-sc0 src
+
+	use_backend be_429_slow_down if mark_seen too_many_reqs_by_user
+	# End Rate limiting config options
+	<% end -%>
 
   <% end -%>
+<% end -%>
+
+<% if @rate_limit_enabled -%>
+backend be_429_slow_down
+	mode http
+	timeout tarpit 2s
+	errorfile 500 <%= node[:haproxy][:platform][:error_dir] %>/429.http
+	http-request tarpit
 <% end -%>


### PR DESCRIPTION
Provides a new option on the loadbalancer resource to allow for rate
limiting per frontend. A integer values is passed and it signifies the
maximum request per minute from an IP.

Also provides a custom 429 error file for haproxy to server when the
rate limit is hit, so clients receive the proper response


Based on the code from https://github.com/sap-oc/crowbar-openstack/issues/21