### PR TITLE
travis: Make our travis config trusty ready

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: ruby
 sudo: false
+cache: bundler
+dist: trusty
+
+rvm: 2.1.9
 
 matrix:
   include:
-    - rvm: 2.1.0
-      gemfile: Gemfile
+    - gemfile: Gemfile
       env: RAKEDIR=.
-    - rvm: 2.1.0
-      gemfile: chef/cookbooks/pacemaker/Gemfile
+    - gemfile: chef/cookbooks/pacemaker/Gemfile
       env: RAKEDIR=chef/cookbooks/pacemaker
 
 script: cd $RAKEDIR && bundle exec rake


### PR DESCRIPTION
Travis started switching to the trusty image which breaks some of our
current setting. This PR fixes them.

cache: this speeds up the hound PR tests
dist: specify the dist to not mix between trusty and precise
rvm: 2.1.0 is not available anymore, switch to 2.1.9 which is used in SP3