### PR TITLE
pacemaker: Use --wait with crm configure command

### DIFF
--- a/chef/cookbooks/pacemaker/libraries/pacemaker/cib_object.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/cib_object.rb
@@ -238,7 +238,7 @@ module Pacemaker
     end
 
     def configure_command
-      "echo #{quoted_definition} | crm configure load update -"
+      "echo #{quoted_definition} | crm --wait configure load update -"
     end
 
     def reconfigure_command
@@ -246,7 +246,7 @@ module Pacemaker
     end
 
     def delete_command
-      "crm configure delete '#{name}'"
+      "crm --wait configure delete '#{name}'"
     end
   end
 

--- a/chef/cookbooks/pacemaker/spec/helpers/non_runnable_resource.rb
+++ b/chef/cookbooks/pacemaker/spec/helpers/non_runnable_resource.rb
@@ -17,7 +17,7 @@ shared_examples "a non-runnable resource" do |fixture|
 
       provider.run_action :delete
 
-      cmd = "crm configure delete '#{fixture.name}'"
+      cmd = "crm --wait configure delete '#{fixture.name}'"
       expect(@chef_run).to run_execute(cmd)
       expect(@resource).to be_updated
     end

--- a/chef/cookbooks/pacemaker/spec/helpers/runnable_resource.rb
+++ b/chef/cookbooks/pacemaker/spec/helpers/runnable_resource.rb
@@ -53,7 +53,7 @@ shared_examples "a runnable resource" do |fixture|
       expect { provider.run_action :delete }.to \
         raise_error(RuntimeError, expected_error)
 
-      cmd = "crm configure delete '#{fixture.name}'"
+      cmd = "crm --wait configure delete '#{fixture.name}'"
       expect(@chef_run).not_to run_execute(cmd)
       expect(@resource).not_to be_updated
     end
@@ -64,7 +64,7 @@ shared_examples "a runnable resource" do |fixture|
 
       provider.run_action :delete
 
-      cmd = "crm configure delete '#{fixture.name}'"
+      cmd = "crm --wait configure delete '#{fixture.name}'"
       expect(@chef_run).to run_execute(cmd)
       expect(@resource).to be_updated
     end


### PR DESCRIPTION
Sometimes reconfiguring existing resources (e.g. groups) in the cluster
will trigger some resources of the cluster being moved and/or restarted.
Use --wait to block until the transition has finished and the cluster
has settled. This helps to avoid race issues e.g. when pacemaker needs
to restart resources after new resource is added to an existing group.