### PR TITLE
[4.0] haproxy: Make sure that systemd kills haproxy service on restart

### DIFF
--- a/chef/cookbooks/haproxy/files/default/haproxy.service.override.conf
+++ b/chef/cookbooks/haproxy/files/default/haproxy.service.override.conf
@@ -1,0 +1,2 @@
+[Service]
+TimeoutStopSec=30


### PR DESCRIPTION
It's possible that haproxy is unable to close open connections during
restart action so we make sure systemd kills it before we hit pacemaker
service timeout that would ultimately fence the haproxy node (bsc#1056371).

(cherry picked from commit 4e4c6e2138bb765165e938dce132c79e4e4de56b)