### PR TITLE
pacemaker: Add option to not manage stateless active/active services

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+return unless node[:pacemaker][:clone_stateless_services]
+
 # Define pacemaker primitive for apache service
 
 # This is required for the OCF resource agent

--- a/chef/data_bags/crowbar/migrate/pacemaker/200_clone_stateless_services.rb
+++ b/chef/data_bags/crowbar/migrate/pacemaker/200_clone_stateless_services.rb
@@ -1,0 +1,10 @@
+def upgrade(ta, td, a, d)
+  # stay compatible with previous behavior
+  a["clone_stateless_services"] = true unless a.key?("clone_stateless_services")
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("clone_stateless_services") unless ta.key?("clone_stateless_services")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-pacemaker.json
+++ b/chef/data_bags/crowbar/template-pacemaker.json
@@ -47,14 +47,15 @@
       "haproxy": {
         "admin_name": "",
         "public_name": ""
-      }
+      },
+      "clone_stateless_services": true
     }
   },
   "deployment": {
     "pacemaker": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 100,
+      "schema-revision": 200,
       "element_states": {
         "pacemaker-cluster-member"    : [ "readying", "ready", "applying" ],
         "hawk-server"                 : [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-pacemaker.schema
+++ b/chef/data_bags/crowbar/template-pacemaker.schema
@@ -128,7 +128,8 @@
                 "admin_name": { "type": "str", "required": true },
                 "public_name": { "type": "str", "required": true }
               }
-            }
+            },
+            "clone_stateless_services": { "type": "bool", "required": true }
           }
         }
       }

--- a/crowbar_framework/app/views/barclamp/pacemaker/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/pacemaker/_edit_attributes.html.haml
@@ -9,6 +9,10 @@
     %span.help-block
       = t('.crm.no_quorum_policy_hint_html')
 
+    = boolean_field %w(clone_stateless_services)
+    %span.help-block
+      = t('.clone_stateless_services_hint_html')
+
     %fieldset
       %legend
         = t(".stonith_header")

--- a/crowbar_framework/config/locales/pacemaker/en.yml
+++ b/crowbar_framework/config/locales/pacemaker/en.yml
@@ -64,6 +64,15 @@ en:
             down or rebooted; you will have to manually start it after having
             fixed the issue. "Automatic" means that this setting will be set to
             "true" for two-nodes cluster, and to "false" otherwise.'
+        clone_stateless_services: 'Manage stateless active/active services with Pacemaker'
+        clone_stateless_services_hint:
+          'Stateless active/active services can be managed by Pacemaker, or can
+          run as standard services. If they are managed by Pacemaker, then
+          Pacemaker will automatically restart them on failures and will setup
+          cluster-wide constraints to ensure correct ordering when starting
+          services. If they run as standard services, then the complexity of
+          the configuration is reduced and this limits the causes for fencing
+          in case of failures.'
         crm:
           no_quorum_policy: 'Policy when cluster does not have quorum'
           no_quorum_policy_hint_html: 'Refer to the <a href="http://clusterlabs.org/doc/en-US/Pacemaker/1.1-crmsh/html/Pacemaker_Explained/_available_cluster_options.html">pacemaker documentation</a> for a description of each value.'


### PR DESCRIPTION
Pacemaker is not strictly required for stateless active/active services,
since orchestration, fencing, and so on is not necessarily useful in
that case.

Enabling this option does simplify the setup in the OpenStack case quite
significantly, but comes with a cost, like pacemaker not restarting
services that have failed.