### PR TITLE
Add support for multiple Corosync rings

### DIFF
--- a/chef/cookbooks/corosync/attributes/default.rb
+++ b/chef/cookbooks/corosync/attributes/default.rb
@@ -15,11 +15,14 @@
 
 default[:corosync][:cluster_name] = "hacluster"
 
-default[:corosync][:bind_addr]   = "192.168.124.0"
-default[:corosync][:mcast_addr]   = "239.1.2.3"
-default[:corosync][:mcast_port]   = 5405
-default[:corosync][:members]      = []
-default[:corosync][:transport]    = "udp"
+default[:corosync][:transport] = "udpu"
+default[:corosync][:rings] = [{
+  "network" => "admin",
+  "bind_addr" => "192.168.124.0",
+  "mcast_addr" => "239.1.2.3",
+  "mcast_port" => 5405,
+  "members" => ["192.168.124.0"]
+}]
 
 case node[:platform_family]
 when "suse"

--- a/chef/cookbooks/corosync/recipes/config.rb
+++ b/chef/cookbooks/corosync/recipes/config.rb
@@ -34,9 +34,34 @@ unless %(udp udpu).include?(node[:corosync][:transport])
   raise "Invalid transport #{node[:corosync][:transport]}!"
 end
 
-if node[:corosync][:transport] == "udpu" && (node[:corosync][:members].nil? || node[:corosync][:members].empty?)
-  raise "Members have to be defined when using \"udpu\" transport!"
+rings = node[:corosync][:rings]
+
+member_count = nil
+rings.each.with_index do |ring, ring_index|
+  # check for empty
+  if ring[:members].nil? || ring[:members].empty?
+    raise "One or more members are required. The member list of "\
+      "ring #{ring_index} is empty."
+  end
+
+  # check for matching member count across rings
+  if member_count.nil?
+    member_count = ring[:members].length
+  elsif ring[:members].length != member_count
+    raise "All rings must have the same number of members. Ring #{ring_index} "\
+      "has #{ring[:members].length} members but all preceding rings have #{member_count}."
+  end
 end
+
+# gather member addresses together by node for corosync.conf.v2.erb by
+# building and transposing a two dimensional member array that is sorted
+# by ring 0 members to avoid unnecessary configuration reloads
+members_v2 = []
+sort_by_ring0 = node[:corosync][:rings][0][:members]
+node[:corosync][:rings].each do |ring|
+  members_v2.push(ring[:members].sort_by.with_index { |_, i| sort_by_ring0[i] })
+end
+members_v2 = members_v2.transpose
 
 template "/etc/corosync/corosync.conf" do
   if node[:platform] == "suse" && node[:platform_version].to_f < 12.0
@@ -49,10 +74,8 @@ template "/etc/corosync/corosync.conf" do
   mode 0600
   variables(
     cluster_name: node[:corosync][:cluster_name],
-    bind_addr: node[:corosync][:bind_addr],
-    mcast_addr: node[:corosync][:mcast_addr],
-    mcast_port: node[:corosync][:mcast_port],
-    members: node[:corosync][:members],
+    rings: node[:corosync][:rings],
+    members_v2: members_v2,
     transport: node[:corosync][:transport]
   )
 

--- a/chef/cookbooks/corosync/templates/default/corosync.conf.erb
+++ b/chef/cookbooks/corosync/templates/default/corosync.conf.erb
@@ -45,21 +45,23 @@ totem {
         # This specifies the mode of redundant ring, which may be none, active, or passive.
         rrp_mode: none
 
+<% @rings.each.with_index do |ring, ring_index| -%>
         interface {
-                ringnumber:     0
-                bindnetaddr:    <%= @bind_addr  %>
+                ringnumber:     <%= ring_index %>
+                bindnetaddr:    <%= ring[:bind_addr]  %>
 <% if @transport == 'udp' -%>
-                mcastaddr:      <%= @mcast_addr %>
+                mcastaddr:      <%= ring[:mcast_addr] %>
 <% elsif @transport == 'udpu' -%>
-  <% @members.sort.each do |memberaddr| -%>
+  <% ring[:members].each do |memberaddr| -%>
                 member {
                         memberaddr:     <%= memberaddr %>
                 }
   <% end -%>
 <% end -%>
-                mcastport:      <%= @mcast_port %>
+                mcastport:      <%= ring[:mcast_port] %>
                 ttl:            1
         }
+<% end -%>
 
         transport: <%= @transport %>
 }

--- a/chef/cookbooks/corosync/templates/default/corosync.conf.v2.erb
+++ b/chef/cookbooks/corosync/templates/default/corosync.conf.v2.erb
@@ -44,15 +44,19 @@ totem {
 	# interface: define at least one interface to communicate
 	# over. If you define more than one interface stanza, you must
 	# also set rrp_mode.
+<% if @rings.length > 1 -%>
+	rrp_mode: passive
+<% end -%>
+<% @rings.each.with_index do |ring, ring_index| -%>
 	interface {
 		# Rings must be consecutively numbered, starting at 0.
-		ringnumber: 0
+		ringnumber: <%= ring_index %>
 		# This is normally the *network* address of the
 		# interface to bind to. This ensures that you can use
 		# identical instances of this configuration file
 		# across all your cluster nodes, without having to
 		# modify this option.
-		bindnetaddr: <%= @bind_addr  %>
+		bindnetaddr: <%= ring[:bind_addr]  %>
 		# However, if you have multiple physical network
 		# interfaces configured for the same subnet, then the
 		# network address alone is not sufficient to identify
@@ -67,19 +71,20 @@ totem {
 		# addresses across multiple Corosync clusters sharing
 		# the same network.
 <% if @transport == 'udp' -%>
-		mcastaddr: <%= @mcast_addr %>
+		mcastaddr: <%= ring[:mcast_addr] %>
 <% end -%>
 		# Corosync uses the port you specify here for UDP
 		# messaging, and also the immediately preceding
 		# port. Thus if you set this to 5405, Corosync sends
 		# messages over UDP ports 5405 and 5404.
-		mcastport: <%= @mcast_port %>
+		mcastport: <%= ring[:mcast_port] %>
 		# Time-to-live for cluster communication packets. The
 		# number of hops (routers) that this ring will allow
 		# itself to pass. Note that multicast routing must be
 		# specifically enabled on most network routers.
 		ttl: 1
 	}
+<% end -%>
 
 	transport: <%= @transport %>
 }
@@ -110,15 +115,15 @@ logging {
 	}
 }
 
-<% if @transport == 'udpu' -%>
 nodelist {
-  <% @members.sort.each do |memberaddr| -%>
+  <% @members_v2.each do |ring_addrs| -%>
 	node {
-		ring0_addr: <%= memberaddr %>
+    <% ring_addrs.each.with_index do |ring_addr, ring_index| -%>
+		ring<%= ring_index %>_addr: <%= ring_addr %>
+    <% end -%>
 	}
   <% end -%>
 }
-<% end -%>
 
 quorum {
 	# Enable and configure quorum subsystem (default: off)

--- a/chef/cookbooks/corosync/templates/default/firewall.erb
+++ b/chef/cookbooks/corosync/templates/default/firewall.erb
@@ -9,7 +9,7 @@
 TCP="5560 7630 21064"
 
 # space separated list of allowed UDP ports
-UDP="<%= @mcast_port %>"
+UDP="<%= @mcast_ports.join(" ") %>"
 
 # space separated list of allowed RPC services
 RPC=""

--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -20,7 +20,12 @@
 require "timeout"
 
 node.normal[:corosync][:cluster_name] = CrowbarPacemakerHelper.cluster_name(node)
-node.normal[:corosync][:bind_addr] = Barclamp::Inventory.get_network_by_type(node, "admin").address
+
+# set bindnetaddr per node, use host address rather than network subnet
+# in case multiple interfaces are configured on the same subnet
+node[:corosync][:rings].each_with_index do |ring, index|
+  ring[:bind_addr] = Barclamp::Inventory.get_network_by_type(node, ring[:network]).address
+end
 
 include_recipe "crowbar-pacemaker::quorum_policy"
 include_recipe "crowbar-pacemaker::stonith"

--- a/chef/data_bags/crowbar/migrate/pacemaker/201_add_ring_array.rb
+++ b/chef/data_bags/crowbar/migrate/pacemaker/201_add_ring_array.rb
@@ -1,0 +1,53 @@
+def upgrade(ta, td, a, d)
+  ring = {
+    "network" => "admin"
+  }
+  if a["corosync"]["bind_addr"]
+    ring["bind_addr"] = a["corosync"]["bind_addr"]
+    a["corosync"].delete "bind_addr"
+  end
+  if a["corosync"]["mcast_addr"]
+    ring["mcast_addr"] = a["corosync"]["mcast_addr"]
+    a["corosync"].delete "mcast_addr"
+  end
+  if a["corosync"]["mcast_port"]
+    ring["mcast_port"] = a["corosync"]["mcast_port"]
+    a["corosync"].delete "mcast_port"
+  end
+  if a["corosync"]["members"]
+    ring["members"] = a["corosync"]["members"]
+    a["corosync"].delete "members"
+  end
+  a["corosync"]["rings"] = [ring]
+
+  # Are we a proposal? If yes, then look for the applied role if it exists and modify it
+  # (the pacemaker barclamp adds an required_post_chef_calls attribute to the
+  # deployment part of the role, so we can use that to know if this is the proposal or not)
+  # Note that we don't do this step when migrating the role because this would imply
+  # loading/saving the role, while the migration scripts will save the role later on
+  # with some data that was already loaded before, therefore outdated, and that
+  # would break the migration
+  unless d.key?("required_post_chef_calls")
+    begin
+      role = Chef::Role.load(d["config"]["environment"])
+      role[:corosync][:rings] = [ring]
+      role.save
+    rescue Net::HTTPServerException => e # role does not exist on the chef server
+      raise e if e.response.code != "404"
+    end
+  end
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  if a["corosync"]["rings"] && !a["corosync"]["rings"].empty?
+    ring = a["corosync"]["rings"][0]
+    a["corosync"]["bind_addr"] = ring["bind_addr"] if ring["bind_addr"]
+    a["corosync"]["mcast_addr"] = ring["mcast_addr"] if ring["mcast_addr"]
+    a["corosync"]["mcast_port"] = ring["mcast_port"] if ring["mcast_port"]
+    a["corosync"]["members"] = ring["members"] if ring["members"]
+  end
+  a["corosync"].delete "rings"
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-pacemaker.json
+++ b/chef/data_bags/crowbar/template-pacemaker.json
@@ -5,10 +5,15 @@
     "pacemaker": {
       "corosync": {
         "transport": "udpu",
-        "mcast_addr": "239.255.0.1",
-        "mcast_port": 5405,
         "password": "crowbar",
-        "require_clean_for_autostart_wrapper": "auto"
+        "require_clean_for_autostart_wrapper": "auto",
+        "rings": [
+          {
+            "network": "admin",
+            "mcast_addr": "",
+            "mcast_port": 5405
+          }
+        ]
       },
       "crm": {
         "no_quorum_policy": "stop"
@@ -55,7 +60,7 @@
     "pacemaker": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 200,
+      "schema-revision": 201,
       "element_states": {
         "pacemaker-cluster-member"    : [ "readying", "ready", "applying" ],
         "hawk-server"                 : [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-pacemaker.schema
+++ b/chef/data_bags/crowbar/template-pacemaker.schema
@@ -17,10 +17,21 @@
               "required": true,
               "mapping": {
                 "transport": { "type": "str", "required": true },
-                "mcast_addr": { "type": "str", "required": true },
-                "mcast_port": { "type": "int", "required": true },
                 "password": { "type": "str", "required": true },
-                "require_clean_for_autostart_wrapper": { "type": "str", "required": true, "pattern": "/^true$|^false$|^auto$/" }
+                "require_clean_for_autostart_wrapper": { "type": "str", "required": true, "pattern": "/^true$|^false$|^auto$/" },
+                "rings": {
+                  "type": "seq",
+                  "required": true,
+                  "sequence": [ {
+                    "type": "map",
+                    "required": true,
+                    "mapping": {
+                      "network": { "type": "str", "required": true },
+                      "mcast_addr": { "type": "str", "required": true },
+                      "mcast_port": { "type": "int", "required": true }
+                    }
+                  } ]
+                }
               }
             },
             "crm": {

--- a/crowbar_framework/app/views/barclamp/pacemaker/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/pacemaker/_edit_attributes.html.haml
@@ -3,7 +3,43 @@
     = header show_raw_deployment?, true
 
   .panel-body
-    = select_field %w(corosync transport), :collection => :transport_for_pacemaker
+    = select_field %w(corosync transport), :collection => :transport_for_pacemaker, "data-showit" => ["udp", "udpu"].join(";"), "data-showit-target" => ".ring_udp_container;.ring_udpu_container", "data-showit-direct" => "true"
+
+    %script#ring-entries{ :type => "text/x-handlebars-template" }
+      #corosync-rings
+        {{#each entries}}
+        %ul.list-group{ :id => "ring-index-{{@index}}" }
+          %li.list-group-item.active
+            %fieldset
+              %legend
+                = t('.corosync.parameters', :index => "{{inc @index}}")
+              {{#if ../at_min_entries }}
+              {{else}}
+              = link_to icon_tag("trash"), "#", :class => "corosync-ring-delete pull-right delete", "data-ringid" => "{{@index}}"
+              {{/if}}
+              = string_field %w(corosync rings {{@index}} network)
+              %div{ :class => "ring_udp_container" }
+                = string_field %w(corosync rings {{@index}} mcast_addr)
+        {{/each}}
+
+    %fieldset
+      %legend
+        = t(".corosync.listheader")
+
+      #corosync-rings
+        = t(".corosync.loading_text")
+
+      %ul.list-group{ :id => "ring-add" }
+        %fieldset
+          %legend
+            = t(".corosync.addheader")
+
+          = string_field %w(corosync rings index network)
+          %div{ :class => "ring_udp_container" }
+            = string_field %w(corosync rings index mcast_addr)
+
+          .form-group.pull-left
+            %input{ :id => "add-ring-button", :class => "form-control", :type => "button", :value => "Add Ring" }
 
     = select_field %w(crm no_quorum_policy), :collection => :no_quorum_policy_for_pacemaker
     %span.help-block

--- a/crowbar_framework/config/locales/pacemaker/en.yml
+++ b/crowbar_framework/config/locales/pacemaker/en.yml
@@ -64,6 +64,15 @@ en:
             down or rebooted; you will have to manually start it after having
             fixed the issue. "Automatic" means that this setting will be set to
             "true" for two-nodes cluster, and to "false" otherwise.'
+          loading_text: 'Loading rings...'
+          listheader: 'Corosync Rings'
+          parameters: 'Ring %{index} Parameters'
+          addheader: 'Add new Corosync Ring'
+          rings:
+            index:
+              network: 'Network'
+              mcast_addr: 'Multicast Address'
+              mcast_port: 'Multicast Port'
         clone_stateless_services: 'Manage stateless active/active services with Pacemaker'
         clone_stateless_services_hint:
           'Stateless active/active services can be managed by Pacemaker, or can
@@ -137,6 +146,15 @@ en:
         drbd: 'Setting up DRBD requires a cluster of two nodes.'
         ha_repo: 'The SLE HA repositories have not been setup.'
         transport_value: 'Invalid transport value: %{transport}.'
+        ring_network_too_many: 'Too many rings specified. Only two rings are allowed.'
+        ring_network_empty: 'A network must be specified for the %{ring_ordinal} corosync ring.'
+        ring_network_notfound: 'Network "%{ring_network}" not found for the %{ring_ordinal} corosync ring.'
+        ring_network_notunique: 'The network "%{ring_network}" has been specified more than once.'
+        allocate_ip: 'Failed to allocate address for node "%{node}" on network "%{network}" (Error %{retcode}).'
+        mcast_addr_empty_free: 'A multicast address for ring %{ring_index} is required. Multicast address %{free_addr} is available.'
+        mcast_addr_used_free: 'The specified multicast address %{used_addr} for ring %{ring_index} is in use but %{free_addr} is available.'
+        mcast_addr_used_none_avail: 'All multicast addresses are in use, including %{used_addr}.'
+        mcast_addr_none_avail: 'All multicast addresses are in use.'
         quorum_policy: 'Invalid no-quorum-policy value: %{no_quorum_policy}.'
         platform: 'All nodes in proposal must have the same platform.'
         pacemaker_proposal: 'Nodes cannot be part of multiple Pacemaker proposals, but %{other_member} is already part of proposal \"%{p_name}\".'


### PR DESCRIPTION
Customer has requested the ability to configure an additional corosync
ring to "fully leverage the second bond in their dual bond environment".
The pacemaker cluster nodes will have visibility of one another over
both bonds and, when a failure occurs on the first bond, a cluster
failure will be averted due to the existence of the second ring over
the second bond.

In order to accomplish this, the flat list of single ring attributes
and web UI form fields is replaced by an array and _**n**_ number of web UI
form fields to support _**n**_ number of rings. The UI and validation code
restrict the maximum number of rings to 2. If there is ever a need for
for more rings, simply search for '2', 'two', and 'second' and make
the appropriate changes.