### PR TITLE
haproxy: Add location contraint to VIP directly

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/haproxy.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/haproxy.rb
@@ -84,6 +84,8 @@ if node[:pacemaker][:haproxy][:clusters].key?(cluster_name) && node[:pacemaker][
     end
     vip_primitives << vip_primitive
     transaction_objects << "pacemaker_primitive[#{vip_primitive}]"
+    location_name = openstack_pacemaker_controller_only_location_for vip_primitive
+    transaction_objects << "pacemaker_location[#{location_name}]"
   end
 
   pacemaker_primitive service_name do


### PR DESCRIPTION
When remote nodes are present (in a Compute HA setup) we want to avoid
the VIPs being started on the remote pacemaker nodes. Usually this is
taken care of by a location constraint on the haproxy group. However, if
a VIP is added to the node after the initial deployment. The creation of
the VIP resource and the update of the group happen as to separate
operations on the cluster. In that case it might be that the cluster
tries to launch the VIP on one of the remote nodes first. With the
commit we add the usual "controller_only_location" location constraint
directly on the VIP to avoid that. Note: The location constraint is
somewhat redundant after the haproxy group is updated, but it shouldn't
do any harm.

This is a follow up on: 58093f6f510c1e5697cb6b80cefc5a3a4e1bf55d

(cherry picked from commit f89beeed5315e06bb579b6315af7853a5c3d80c2)

Backport of: https://github.com/crowbar/crowbar-ha/pull/240