### PR TITLE
Use new utils_systemd_service_restart LWRP

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb
@@ -103,3 +103,7 @@ end
 # Override service provider for apache2 resource defined in apache2 cookbook
 resource = resources(service: "apache2")
 resource.provider(Chef::Provider::CrowbarPacemakerService)
+
+# Override setting to not use systemd restart, as this would interact badly with pacemaker
+resource = resources(utils_systemd_service_restart: "apache2")
+resource.action(:disable)

--- a/chef/cookbooks/hawk/metadata.rb
+++ b/chef/cookbooks/hawk/metadata.rb
@@ -7,3 +7,4 @@ long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version "0.0"
 
 depends "pacemaker"
+depends "utils"

--- a/chef/cookbooks/hawk/recipes/server.rb
+++ b/chef/cookbooks/hawk/recipes/server.rb
@@ -24,4 +24,4 @@ service "hawk" do
   supports status: true, restart: true
   action [:enable, :start]
 end
-
+utils_systemd_service_restart "hawk"


### PR DESCRIPTION
**crowbar-pacemaker: Update apache override for systemd restart LWRP**

We don't want systemd and pacemaker to handle restart of apache2 at the
same time, so override the action for the utils_systemd_service_restart
LWRP.

**hawk: Make systemd restart hawk service on failures**

This offers some automatic recovery, which is nice.