### PR TITLE
[4.0] pacemaker: Add missing  operations to the parser

### DIFF
--- a/chef/cookbooks/pacemaker/libraries/pacemaker/resource/primitive.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/resource/primitive.rb
@@ -35,7 +35,7 @@ class Pacemaker::Resource::Primitive < Pacemaker::Resource
     end
 
     self.op = {}
-    %w(start stop monitor).each do |op|
+    %w(start stop monitor promote demote).each do |op|
       h = self.class.extract_hash(@definition, "op #{op}")
       self.op[op] = h unless h.empty?
     end

--- a/chef/cookbooks/pacemaker/spec/fixtures/keystone_primitive.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/keystone_primitive.rb
@@ -23,6 +23,7 @@ class Chef
         ]
         KEYSTONE_PRIMITIVE.op = [
           ["monitor", { "timeout" =>  "60", "interval" => "10s" }],
+          ["promote", { "timeout" => "150", "interval" => "10s" }],
           ["start",   { "timeout" => "240", "interval" => "10s" }]
         ]
         KEYSTONE_PRIMITIVE.attrs_authoritative
@@ -30,7 +31,7 @@ class Chef
 primitive keystone ocf:openstack:keystone \
          params os_auth_url="http://node1:5000/v2.0" os_password="ad\"min$pa&ss'wo%rd" os_tenant_name="openstack" os_username="admin" user="openstack-keystone" \
          meta is-managed="true" \
-         op monitor interval="10s" timeout="60" op start interval="10s" timeout="240"
+         op monitor interval="10s" timeout="60" op promote interval="10s" timeout="150" op start interval="10s" timeout="240"
 EOF
       end
     end

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/primitive_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/primitive_spec.rb
@@ -108,5 +108,11 @@ EOF
     it "should parse the agent" do
       expect(@parsed.agent).to eq(fixture.agent)
     end
+
+    it "should parse all ops" do
+      fixture.op.each do |op, param|
+        expect(@parsed.op[op]).not_to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
The parser for the "op" part of a resource definition was missing the
"promote" and "demote" operations. This was never noticed up to now as
we didn't use them until we introduced galera support in the database
barclamp. This bug caused calls to "crm config" in every chef-client run
for resources that contain custom settings for the "promote" or "demote"
operation.

(cherry picked from commit eda7fc9cde8a46c5109408a518dcf289e0857bda)

Backport of https://github.com/crowbar/crowbar-ha/pull/241