### PR TITLE
Fix the translation label

### DIFF
--- a/crowbar_framework/app/views/barclamp/pacemaker/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/pacemaker/_edit_attributes.html.haml
@@ -11,7 +11,7 @@
 
     = boolean_field %w(clone_stateless_services)
     %span.help-block
-      = t('.clone_stateless_services_hint_html')
+      = t('.clone_stateless_services_hint')
 
     %fieldset
       %legend


### PR DESCRIPTION
clone_stateless_services_hint_html is required by _edit_attributes.html.haml

Introduced by https://github.com/crowbar/crowbar-ha/pull/238