### PR TITLE
[4.0] crowbar-pacemaker: hide output for #cib_up_for_node?

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/libraries/cibattribute.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/cibattribute.rb
@@ -18,7 +18,7 @@ require "rexml/document"
 
 module CrowbarPacemakerCIBAttribute
   def self.cib_up_for_node?
-    system "crm_node -q"
+    system "crm_node -q &>/dev/null"
   end
 
   def self.validate_simple(string, type)


### PR DESCRIPTION
We forgot to redirect stdout and sterr for #cib_up_for_node?, making the
logs be full of 1s and 0s.

This redirects all the output of the command to /dev/null to avoid
filling up the logs with unwanted lines

(cherry picked from commit 464d727ade1e40e8999563c3895a23dafc6d8c57)

Backport of https://github.com/crowbar/crowbar-ha/pull/250