### PR TITLE
drbd: enable autorecovery after split-brain (bsc#1036603)

### DIFF
--- a/chef/cookbooks/drbd/templates/default/resource.erb
+++ b/chef/cookbooks/drbd/templates/default/resource.erb
@@ -19,4 +19,9 @@ resource <%= @resource %> {
       protocol C;
     }
   }
+  net {
+    after-sb-0pri discard-zero-changes;
+    after-sb-1pri discard-secondary;
+    after-sb-2pri disconnect;
+  }
 }


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1036603
There were several cases where DRBD replication went out of sync
without good reason. In that state, postgresql still worked on the primary
but could not be migrated to the secondary.

As documented in http://docs.linbit.com/docs/users-guide-9.0/#s-configure-split-brain-behavior
DRBD comes with builtin handling of split-brain scenarios,
where certain safe cases can be resolved automatically, such as
one node having zero changes compared to the other.