### PR TITLE
pacemaker: provide a option to configure migrate-threshold

### DIFF
--- a/chef/cookbooks/pacemaker/attributes/default.rb
+++ b/chef/cookbooks/pacemaker/attributes/default.rb
@@ -53,6 +53,7 @@ default[:pacemaker][:is_remote] = false
 default[:pacemaker][:crm][:initial_config_file] = "/etc/corosync/crm-initial.conf"
 default[:pacemaker][:crm][:no_quorum_policy] = "ignore"
 default[:pacemaker][:crm][:op_default_timeout] = 60
+default[:pacemaker][:crm][:migration_threshold] = 3
 
 # acceptable CIB syntax version; if lower is detected, we must force its upgrade
 default[:pacemaker][:cib_syntax_version] = "2.4"

--- a/chef/cookbooks/pacemaker/recipes/setup.rb
+++ b/chef/cookbooks/pacemaker/recipes/setup.rb
@@ -28,7 +28,8 @@ template crm_conf do
   variables(
     stonith_enabled: (node[:pacemaker][:stonith][:mode] != "disabled"),
     no_quorum_policy: node[:pacemaker][:crm][:no_quorum_policy],
-    op_default_timeout: node[:pacemaker][:crm][:op_default_timeout]
+    op_default_timeout: node[:pacemaker][:crm][:op_default_timeout],
+    migration_threshold: node[:pacemaker][:crm][:migration_threshold]
   )
 end
 

--- a/chef/cookbooks/pacemaker/templates/default/crm-initial.conf.erb
+++ b/chef/cookbooks/pacemaker/templates/default/crm-initial.conf.erb
@@ -8,4 +8,4 @@ op_defaults $id="op-options" \
         record-pending="true"
 rsc_defaults $id="rsc-options" \
         resource-stickiness="1" \
-        migration-threshold="3"
+        migration-threshold="<%= @migration_threshold %>"

--- a/chef/data_bags/crowbar/migrate/pacemaker/201_migration_threshold.rb
+++ b/chef/data_bags/crowbar/migrate/pacemaker/201_migration_threshold.rb
@@ -1,0 +1,12 @@
+def upgrade(ta, td, a, d)
+  # stay compatible with previous behavior
+  unless a["crm"].key?("migration_threshold")
+    a["crm"]["migration_threshold"] = ta["crm"]["migration_threshold"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["crm"].delete("migration_threshold") unless ta["crm"].key?("migration_threshold")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-pacemaker.json
+++ b/chef/data_bags/crowbar/template-pacemaker.json
@@ -11,7 +11,8 @@
         "require_clean_for_autostart_wrapper": "auto"
       },
       "crm": {
-        "no_quorum_policy": "stop"
+        "no_quorum_policy": "stop",
+        "migration_threshold": 3
       },
       "stonith": {
         "mode": "per_node",
@@ -38,7 +39,7 @@
           "from": "",
           "server": "",
           "prefix": ""
-	}
+        }
       },
       "drbd": {
         "enabled": false,
@@ -55,7 +56,7 @@
     "pacemaker": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 200,
+      "schema-revision": 201,
       "element_states": {
         "pacemaker-cluster-member"    : [ "readying", "ready", "applying" ],
         "hawk-server"                 : [ "readying", "ready", "applying" ],
@@ -77,4 +78,3 @@
     }
   }
 }
-

--- a/chef/data_bags/crowbar/template-pacemaker.schema
+++ b/chef/data_bags/crowbar/template-pacemaker.schema
@@ -27,7 +27,8 @@
               "type": "map",
               "required": true,
               "mapping": {
-                "no_quorum_policy": { "type": "str", "required": true }
+                "no_quorum_policy": { "type": "str", "required": true },
+                "migration_threshold": { "type": "int", "required": true }
               }
             },
             "stonith": {


### PR DESCRIPTION
Provides a new way to configure pacemaker migrate-threshold option
per frontent. An integer value is passed and it signifies the maximun
numbers of retries before migrate a service to other node. Its value
is 3 by default.