### PR TITLE
Added support for op defaults

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/helpers.rb
@@ -398,4 +398,15 @@ module CrowbarPacemakerHelper
 
     existing_resources
   end
+
+  def self.op_defaults(node)
+    return nil unless is_cluster_founder?(node)
+
+    if node[:pacemaker].nil? || node[:pacemaker][:op_defaults].nil?
+      return nil
+    end
+
+    node[:pacemaker][:op_defaults].to_hash
+  end
+
 end

--- a/chef/cookbooks/crowbar-pacemaker/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/helpers.rb
@@ -398,15 +398,4 @@ module CrowbarPacemakerHelper
 
     existing_resources
   end
-
-  def self.op_defaults(node)
-    return nil unless is_cluster_founder?(node)
-
-    if node[:pacemaker].nil? || node[:pacemaker][:op_defaults].nil?
-      return nil
-    end
-
-    node[:pacemaker][:op_defaults].to_hash
-  end
-
 end

--- a/chef/cookbooks/pacemaker/spec/providers/primitive_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/providers/primitive_spec.rb
@@ -2,6 +2,8 @@ require "spec_helper"
 
 require_relative "../helpers/runnable_resource"
 require_relative "../fixtures/keystone_primitive"
+require_relative "../../../crowbar-pacemaker/libraries/helpers.rb"
+
 
 describe "Chef::Provider::PacemakerPrimitive" do
   # for use inside examples:

--- a/chef/data_bags/crowbar/migrate/pacemaker/201_op_defaults.rb
+++ b/chef/data_bags/crowbar/migrate/pacemaker/201_op_defaults.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["op_defaults"] = ta["op_defaults"] unless a.key? "op_defaults"
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("op_defaults") unless ta.key? "op_defaults"
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-pacemaker.json
+++ b/chef/data_bags/crowbar/template-pacemaker.json
@@ -54,7 +54,12 @@
         "admin_name": "",
         "public_name": ""
       },
-      "clone_stateless_services": true
+      "clone_stateless_services": true,
+      "op_defaults": {
+        "monitor": {
+          "on-fail": ""
+        }
+      }
     }
   },
   "deployment": {

--- a/chef/data_bags/crowbar/template-pacemaker.schema
+++ b/chef/data_bags/crowbar/template-pacemaker.schema
@@ -141,7 +141,20 @@
                 "public_name": { "type": "str", "required": true }
               }
             },
-            "clone_stateless_services": { "type": "bool", "required": true }
+            "clone_stateless_services": { "type": "bool", "required": true },
+            "op_defaults": {
+              "type": "map",
+              "required": true,
+              "mapping": {
+                "monitor": {
+                  "type": "map",
+                  "required": true,
+                  "mapping": {
+                    "on-fail": { "type": "str", "required": true, "pattern": "/^ignore$|^block$|^stop$|^restart$|^fence$|^standby$|^$/"}
+                  }
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
**pacemaker: added support for op defaults**

We needed to add a default option for the pacemaker op defaults. In
particular we are interested in offering a default for "op monitor
on-fail" action.

Pacemaker does not offer a configuration option to offer such defaults
for all resources. There's a way to do it for a single resource with
rsc_defaults, but that is not our case. Also with Pacemaker you could
link one resource operations to another one with 'id-ref', but in that
case if you modify the reference resource it will cascade changes to all
other resourced.

This approach allows to store in the pacemaker barclamp a default for
op. In this case we are only interested in op monitor but could easily
be extended later on.

This change by itself does not fullfill the requirement. It needs the
'pacemaker-primitive' to read the value we store here.

**pacemaker: primitive to read global op defaults**

The pacemaker_primitive object has been extended in order to add support
for global 'op monitor on-fail' defaults. In this commit we consider the
barclamp schema already supports an option to configure the defaults for
the 'op monitor on-fail' action.

The primitive will read that value from the founder node and set it to
all 'op monitor on-fail' actions. Should the user had configured
manually the defaults (editing the barclamp), then those manually
configured values will prevail.

This code required the 'op monitor on-fail' attribute to be configured
as a Chef::Node::Attribute class. The main reason is that this class
keeps the original values configured in the barclamp as well as the new
ones, so it is possible to roll-back changes.

Some barclamps set this attribute as a Hash object. In that case there's
no possible rollback. The behavior in this case will be to not modify
it, in order not to break anything. The user can still manually set the
values in that particular barclamp to suit their needs, but not as a
global option.