### PR TITLE
crowbar-framework: remove useless metadata

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/metadata.rb
+++ b/chef/cookbooks/crowbar-pacemaker/metadata.rb
@@ -12,5 +12,3 @@ depends "hawk"
 depends "lvm"
 depends "pacemaker"
 depends "utils"
-
-recommends "crowbar-openstack"


### PR DESCRIPTION
recommends and suggests are useless in the metadata files as they dont
do anything and are deprecated[0]

[0] https://chef.github.io/chef-rfc/rfc085-remove-unused-metadata.html