### PR TITLE
crowbar-pacemaker: Reset sync-marks for all nodes

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -79,7 +79,11 @@ end
 
 if CrowbarPacemakerHelper.is_cluster_founder?(node) && node[:pacemaker][:reset_sync_marks]
   # we can't reset sync marks if the pacemaker stack is not set up...
-  CrowbarPacemakerSynchronization.reset_marks(node) if node[:pacemaker][:setup]
+  if node[:pacemaker][:setup]
+    CrowbarPacemakerHelper.cluster_nodes(node).each do |cluster_node|
+      CrowbarPacemakerSynchronization.reset_marks(cluster_node)
+    end
+  end
   # ... but we don't want to block the other nodes forever
   node.set[:pacemaker][:reset_sync_marks] = false
   dirty = true


### PR DESCRIPTION
Up to now we only reset the synchronisation marks for the founder node
when re-applying a barlcamp. The reset needs to happen for all nodes of
a cluster. Otherwise we will run into synchronisation issues if e.g. the
first deployment of a barclamp fails and all nodes except of the founder
still have the sync marks set.

(cherry picked from commit 41e9f4e91b9e67686cf6b6a5ebedb8c9b8790fe1)

Backport of https://github.com/crowbar/crowbar-ha/pull/270