### PR TITLE
corosync: remove nonsensical ring default

### DIFF
--- a/chef/cookbooks/corosync/attributes/default.rb
+++ b/chef/cookbooks/corosync/attributes/default.rb
@@ -16,13 +16,7 @@
 default[:corosync][:cluster_name] = "hacluster"
 
 default[:corosync][:transport] = "udpu"
-default[:corosync][:rings] = [{
-  "network" => "admin",
-  "bind_addr" => "192.168.124.0",
-  "mcast_addr" => "239.1.2.3",
-  "mcast_port" => 5405,
-  "members" => ["192.168.124.0"]
-}]
+default[:corosync][:rings] = []
 
 case node[:platform_family]
 when "suse"


### PR DESCRIPTION
The default attributes are getting merged with the default from the
crowbar barclamp proposal, rather than overwritten, so we always
have two entries, one broken one. For upgraded installs this is
basically desastrously breaking the install, as found out in a live
demo. All debugging thanks to Adam.

(cherry picked from commit 1cbacc8364a2d93063de8c4fc3c374b7a2511b9a)