### PR TITLE
[4.0] haproxy: Check for existence of "content[:stick]"

### DIFF
--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -47,7 +47,7 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
 
     <% if content[:use_ssl] # http://www.haproxy.com/blog/maintain-affinity-based-on-ssl-session-id/ -%>
 	# maximum SSL session ID length is 32 bytes.
-	stick-table type binary len 32 size 30k expire <%= content[:stick][:expire] %>
+	stick-table type binary len 32 size 30k expire <%= content[:stick] ? content[:stick][:expire] : "32m" %>
 
 	acl clienthello req_ssl_hello_type 1
 	acl serverhello rep_ssl_hello_type 2
@@ -82,7 +82,7 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
 	stick match req.cook(<%= cookie %>)
       <% end -%>
     <% end -%>
-    <% if content[:stick][:on] -%>
+    <% if content[:stick] && content[:stick][:on] && !content[:stick][:on].empty? -%>
         stick-table type ip size 1
         stick on <%= content[:stick][:on] %>
     <% end -%>


### PR DESCRIPTION
(backports #258)

After a cowbar-ha update, the 'stick' attribute introduced in PR #209 is missing from the existing `node[:haproxy][sections]` entries, which may result in errors such as:

```
Chef::Mixin::Template::TemplateError
------------------------------------
undefined method `[]' for nil:NilClass
```

This PR adds checks for the existence of the 'stick' attribute before dereferencing it.

Fixes [bsc#1062889](https://bugzilla.suse.com/show_bug.cgi?id=1062889).