### PR TITLE
[4.0] Allow default-server options to be set in haproxy

### DIFF
--- a/chef/cookbooks/haproxy/providers/loadbalancer.rb
+++ b/chef/cookbooks/haproxy/providers/loadbalancer.rb
@@ -61,6 +61,7 @@ action :create do
       section["options"] = [["tcpka", "httplog", "forwardfor"], section["options"]].flatten
     end
   end
+  section["default_server"] = new_resource.default_server unless new_resource.default_server.empty?
   section["servers"] = new_resource.servers
 
   if new_resource.rate_limit && new_resource.rate_limit.to_i != 0

--- a/chef/cookbooks/haproxy/resources/loadbalancer.rb
+++ b/chef/cookbooks/haproxy/resources/loadbalancer.rb
@@ -30,5 +30,6 @@ attribute :balance, kind_of: String,  default: "",
 attribute :use_ssl, kind_of: [TrueClass, FalseClass], default: false
 attribute :stick,   kind_of: Hash,    default: {}
 attribute :options, kind_of: Array,   default: []
+attribute :default_server, kind_of: String,  default: ""
 attribute :servers, kind_of: Array,   default: []
 attribute :rate_limit, kind_of: Integer, default: nil

--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -39,7 +39,7 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
   <% node[:haproxy][:sections][type].keys.sort.each do |name| -%>
     <% content = node[:haproxy][:sections][type][name] -%>
 <%= type %> <%= name %>
-    bind <%= content[:address] %>:<%= content[:port] %>
+	bind <%= content[:address] %>:<%= content[:port] %>
 	mode <%= content[:mode] %>
     <% unless content[:balance].nil? -%>
 	balance <%= content[:balance] %>
@@ -88,6 +88,10 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
     <% end -%>
     <% content[:options].each do |option| -%>
 	option <%= option %>
+    <% end -%>
+
+    <% unless content[:default_server].nil? -%>
+	default-server <%= content[:default_server] %>
     <% end -%>
 
     <% content[:servers].each do |server| -%>


### PR DESCRIPTION
This allows defaults for each server to be set (such as inter etc).
This will simplify common params for servers such as monitoring
details.

(cherry picked from commit 8ac75cf6d3db958997e47e62b79e14b400fe1131)

Backport of https://github.com/crowbar/crowbar-ha/pull/242