### PR TITLE
haproxy: make maxconn parameter configurable (bsc#1068962)

### DIFF
--- a/chef/cookbooks/haproxy/providers/loadbalancer.rb
+++ b/chef/cookbooks/haproxy/providers/loadbalancer.rb
@@ -61,6 +61,7 @@ action :create do
       section["options"] = [["tcpka", "httplog", "forwardfor"], section["options"]].flatten
     end
   end
+  section["max_connections"] = new_resource.max_connections unless new_resource.max_connections.nil?
   section["default_server"] = new_resource.default_server unless new_resource.default_server.empty?
   section["servers"] = new_resource.servers
 

--- a/chef/cookbooks/haproxy/resources/loadbalancer.rb
+++ b/chef/cookbooks/haproxy/resources/loadbalancer.rb
@@ -24,6 +24,7 @@ attribute :name,    kind_of: String,  name_attribute: true
 attribute :type,    kind_of: String,  default: "listen", equal_to: ["listen", "backend", "frontend"]
 attribute :address, kind_of: String,  default: "0.0.0.0"
 attribute :port,    kind_of: Integer, default: 0
+attribute :max_connections, kind_of: Integer, default: nil
 attribute :mode,    kind_of: String,  default: "http", equal_to: ["http", "tcp", "health"]
 attribute :balance, kind_of: String,  default: "",
           equal_to: ["", "roundrobin", "static-rr", "leastconn", "first", "source"]

--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -90,6 +90,10 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
 	option <%= option %>
     <% end -%>
 
+    <% unless content[:max_connections].nil? -%>
+	maxconn <%= content[:max_connections] %>
+    <% end -%>
+
     <% unless content[:default_server].nil? -%>
 	default-server <%= content[:default_server] %>
     <% end -%>


### PR DESCRIPTION
It seems at least on the concurrent Galera DB connection side we
can easily hit the default limit of 2000 parallel connections. Raise
it to the global connection limit.