### PR TITLE
[4.0] pacemaker: deal with nil op attributes

### DIFF
--- a/chef/cookbooks/pacemaker/libraries/pacemaker/resource/primitive.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/resource/primitive.rb
@@ -74,7 +74,7 @@ class Pacemaker::Resource::Primitive < Pacemaker::Resource
   def self.op_string(ops)
     return "" if !ops || ops.empty?
     ops.sort.map do |op, attrs|
-      if attrs.empty?
+      if attrs.nil? || attrs.empty?
         nil
       else
         # crm seems to append interval=0 when there are attributes, but no


### PR DESCRIPTION
Backport from https://github.com/crowbar/crowbar-ha/pull/280

When flatting out the list of 'op' parameters in pacemaker primitive
resource, that list can be nil instead of empty. This change addresses
that situation.