### PR TITLE
[4.0] pacemaker: Allow having multiple op settings for master/slave

### DIFF
--- a/chef/cookbooks/pacemaker/libraries/pacemaker/resource.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/resource.rb
@@ -32,13 +32,27 @@ module Pacemaker
     #         meta target-role="Started" is-managed="true" \
     #         op monitor interval="10" timeout=30s \
     #         op start interval="10s" timeout="240" \
-    #
-    # This method extracts a Hash from one of the params / meta / op lines.
-    def self.extract_hash(obj_definition, data_type)
-      unless obj_definition =~ /\s+#{data_type} (.*?)\s*\\?$/
-        return {}
-      end
 
+    # This method finds all the entries matching a data_type. This can deal
+    # with a string like:
+    #         op monitor interval="10" timeout=30s \
+    #         op monitor interval="10" timeout=30s role=Master \
+    #         op monitor interval="10" role=Slave op monitor role=Foo \
+    # That is: entries on multiple lines, and even intries within the same line.
+    def self.find_all_to_extract(string, data_type)
+      results = string.scan(/\s+#{data_type} (.*?)\s*\\?$/).map { |x| x[0] }
+      unless results.empty?
+        # Careful here: we make sure we keep the results in the right order,
+        # even when going recursive
+        recursive_results = results.map { |x| [x, find_all_to_extract(x, data_type)] }
+        results = recursive_results.flatten
+      end
+      results
+    end
+
+    # This method extracts a Hash from one of the params / meta / op matching
+    # the requested data_type.
+    def self.extract_hash_from_one(string, data_type)
       h = {}
       # Shellwords.split behaves just like word splitting in Bourne
       # shell, eating backslashes, so we have to escape them.  This
@@ -47,7 +61,7 @@ module Pacemaker
       # except is escaped double quotes (\"), for which we want the
       # backslash to be eaten, because complex crm attribute values
       # are represented inside double quotes, e.g. foo="bar\"baz"
-      hash_string = $1.gsub(/\\([^"])/) { |m| '\\' + m }
+      hash_string = string.gsub(/\\([^"])/) { |m| '\\' + m }
 
       Shellwords.split(hash_string).each do |kvpair|
         break if kvpair == "op"
@@ -59,6 +73,27 @@ module Pacemaker
         h[k] = v.sub(/^"(.*)"$/, "\1")
       end
       h
+    end
+
+    # This method extracts the list of Hash from the params / meta / op
+    # matching the requested data_type. This should never return more than one
+    # result, unless we're looking for an op.
+    def self.extract_hash(obj_definition, data_type)
+      results = find_all_to_extract(obj_definition, data_type).map do |string|
+        extract_hash_from_one(string, data_type)
+      end
+
+      if results.empty?
+        {}
+      elsif results.length == 1
+        results[0]
+      else
+        if data_type !~ /^op (.*)$/
+          raise "Many results when extracting hash for #{data_type} from "\
+              "#{obj_definition} while this is not an op!"
+        end
+        results
+      end
     end
   end
 end

--- a/chef/cookbooks/pacemaker/libraries/pacemaker/resource/primitive.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/resource/primitive.rb
@@ -17,7 +17,7 @@ class Pacemaker::Resource::Primitive < Pacemaker::Resource
   end
 
   def self.attrs_to_copy_from_chef
-    %w(agent params meta op)
+    %w[agent params meta op]
   end
 
   def parse_definition
@@ -28,14 +28,14 @@ class Pacemaker::Resource::Primitive < Pacemaker::Resource
     self.name  = $1
     self.agent = $2
 
-    %w(params meta).each do |data_type|
+    %w[params meta].each do |data_type|
       hash = self.class.extract_hash(@definition, data_type)
       writer = (data_type + "=").to_sym
       send(writer, hash)
     end
 
     self.op = {}
-    %w(start stop monitor promote demote notify probe migrate_to migrate_from).each do |op|
+    %w[start stop monitor promote demote notify probe migrate_to migrate_from].each do |op|
       h = self.class.extract_hash(@definition, "op #{op}")
       self.op[op] = h unless h.empty?
     end
@@ -53,7 +53,7 @@ class Pacemaker::Resource::Primitive < Pacemaker::Resource
 
   def definition_from_attributes
     str = "#{self.class.object_type} #{name} #{agent}"
-    %w(params meta op).each do |data_type|
+    %w[params meta op].each do |data_type|
       unless send(data_type).empty?
         data_string = send("#{data_type}_string")
         str << continuation_line(data_string)
@@ -67,7 +67,7 @@ class Pacemaker::Resource::Primitive < Pacemaker::Resource
     "params " +
     params.sort.map do |key, value|
       safe = value.is_a?(String) ? value.gsub('"', '\\"') : value.to_s
-      %'#{key}="#{safe}"'
+      %(#{key}="#{safe}")
     end.join(" ")
   end
 
@@ -87,7 +87,7 @@ class Pacemaker::Resource::Primitive < Pacemaker::Resource
           # Shouldn't be necessary to escape " here since we don't
           # expect any arbitrary string values, but better to be safe.
           safe = value.is_a?(String) ? value.gsub('"', '\\"') : value.to_s
-          %'#{key}="#{safe}"'
+          %(#{key}="#{safe}")
         end.join(" ")
     end
   end

--- a/chef/cookbooks/pacemaker/libraries/pacemaker/resource/primitive.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/resource/primitive.rb
@@ -35,7 +35,7 @@ class Pacemaker::Resource::Primitive < Pacemaker::Resource
     end
 
     self.op = {}
-    %w(start stop monitor promote demote).each do |op|
+    %w(start stop monitor promote demote notify probe migrate_to migrate_from).each do |op|
       h = self.class.extract_hash(@definition, "op #{op}")
       self.op[op] = h unless h.empty?
     end

--- a/chef/cookbooks/pacemaker/spec/fixtures/keystone_primitive.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/keystone_primitive.rb
@@ -22,7 +22,10 @@ class Chef
           ["is-managed", "true"]
         ]
         KEYSTONE_PRIMITIVE.op = [
-          ["monitor", { "timeout" =>  "60", "interval" => "10s" }],
+          ["monitor", [
+            { "timeout" =>  "60",     "interval" => "10s" },
+            { "role"    =>  "Master", "interval" => "15s" }
+          ]],
           ["promote", { "timeout" => "150", "interval" => "10s" }],
           ["start",   { "timeout" => "240", "interval" => "10s" }]
         ]
@@ -31,7 +34,7 @@ class Chef
 primitive keystone ocf:openstack:keystone \
          params os_auth_url="http://node1:5000/v2.0" os_password="ad\"min$pa&ss'wo%rd" os_tenant_name="openstack" os_username="admin" user="openstack-keystone" \
          meta is-managed="true" \
-         op monitor interval="10s" timeout="60" op promote interval="10s" timeout="150" op start interval="10s" timeout="240"
+         op monitor interval="10s" timeout="60" op monitor interval="15s" role="Master" op promote interval="10s" timeout="150" op start interval="10s" timeout="240"
 EOF
       end
     end

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/primitive_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/primitive_spec.rb
@@ -65,6 +65,24 @@ describe Pacemaker::Resource::Primitive do
       }
       expect(fixture.op_string).to eq(%'op monitor baz="qux" foo="bar" interval="0"')
     end
+
+    it "should return a resource op string with multiple monitors" do
+      fixture.op = {
+        "monitor" => [
+          {
+            "foo" => "bar",
+            "baz" => "qux"
+          },
+          {
+            "oof" => "rab",
+            "zab" => "xuq"
+          }
+        ]
+      }
+      expect(fixture.op_string).to eq(
+        %'op monitor baz="qux" foo="bar" interval="0" op monitor interval="0" oof="rab" zab="xuq"'
+      )
+    end
   end
 
   it_should_behave_like "with meta attributes"

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/primitive_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource/primitive_spec.rb
@@ -63,7 +63,7 @@ describe Pacemaker::Resource::Primitive do
           "baz" => "qux"
         }
       }
-      expect(fixture.op_string).to eq(%'op monitor baz="qux" foo="bar" interval="0"')
+      expect(fixture.op_string).to eq(%(op monitor baz="qux" foo="bar" interval="0"))
     end
 
     it "should return a resource op string with multiple monitors" do
@@ -80,7 +80,7 @@ describe Pacemaker::Resource::Primitive do
         ]
       }
       expect(fixture.op_string).to eq(
-        %'op monitor baz="qux" foo="bar" interval="0" op monitor interval="0" oof="rab" zab="xuq"'
+        %(op monitor baz="qux" foo="bar" interval="0" op monitor interval="0" oof="rab" zab="xuq")
       )
     end
   end

--- a/chef/cookbooks/pacemaker/spec/providers/primitive_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/providers/primitive_spec.rb
@@ -102,13 +102,13 @@ EOF
 
     it "should modify the primitive if it has different op values" do
       expected_configure_cmd_args = [
-        fixture.reconfigure_command.gsub("60", "120")
+        fixture.reconfigure_command.gsub("240", "120")
       ]
       test_modify(expected_configure_cmd_args) do
         new_op = Hash[fixture.op]
         # Ensure we're not modifying our expectation as well as the input
-        new_op["monitor"] = new_op["monitor"].dup
-        new_op["monitor"]["timeout"] = "120"
+        new_op["start"] = new_op["start"].dup
+        new_op["start"]["timeout"] = "120"
         @resource.op new_op
       end
     end


### PR DESCRIPTION
It turns out that we can have multiple entries for the same data type.
For instance, when using ms, we need to define multiple "op monitor"
with different roles:
  https://clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Pacemaker_Explained/_monitoring_multi_state_resources.html

Also, add support for missing op operations (notify will be used).

Backport of https://github.com/crowbar/crowbar-ha/pull/282