### PR TITLE
pacemaker: Alert resource

### DIFF
--- a/chef/cookbooks/pacemaker/libraries/pacemaker/alert.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/alert.rb
@@ -1,0 +1,36 @@
+require "shellwords"
+
+require_relative "cib_object"
+
+module Pacemaker
+  class Alert < Pacemaker::CIBObject
+    register_type :alert
+
+    attr_accessor :handler, :receiver
+
+    def self.attrs_to_copy_from_chef
+      %w(handler receiver)
+    end
+
+    def parse_definition
+      unless @definition =~ /\A#{self.class.object_type} (\S+) (\S+)[\\\s]+to (\S+)/
+        raise Pacemaker::CIBObject::DefinitionParseError, \
+              "Couldn't parse definition '#{@definition}'"
+      end
+      self.name = Regexp.last_match(1)
+      self.handler = Regexp.last_match(2)
+      self.receiver = Regexp.last_match(3)
+
+      attrs_authoritative
+    end
+
+    def definition_from_attributes
+      str = "#{self.class.object_type} #{name} #{handler}"
+      str << continuation_line("to #{receiver}") unless receiver.empty?
+    end
+
+    def self.description
+      "alert"
+    end
+  end
+end

--- a/chef/cookbooks/pacemaker/providers/alert.rb
+++ b/chef/cookbooks/pacemaker/providers/alert.rb
@@ -1,0 +1,63 @@
+# Cookbook Name:: pacemaker
+# Provider:: alert
+#
+# Copyright:: 2017, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+this_dir = ::File.dirname(__FILE__)
+require ::File.expand_path("../libraries/pacemaker/cib_object", this_dir)
+require ::File.expand_path("../libraries/pacemaker", this_dir)
+require ::File.expand_path("../libraries/chef/mixin/pacemaker", this_dir)
+
+include Chef::Mixin::Pacemaker::StandardCIBObject
+
+action :create do
+  name = new_resource.name
+
+  if @current_resource_definition.nil?
+    create_resource(name)
+  else
+    maybe_modify_resource(name)
+  end
+end
+
+action :update do
+  standard_update_action
+end
+
+action :delete do
+  next unless @current_resource
+  standard_delete_resource
+end
+
+def cib_object_class
+  ::Pacemaker::Alert
+end
+
+def load_current_resource
+  standard_load_current_resource
+end
+
+def resource_attrs
+  [:handler, :receiver]
+end
+
+def create_resource(name)
+  standard_create_resource
+end
+
+def maybe_modify_resource(name)
+  standard_maybe_modify_resource(name)
+end

--- a/chef/cookbooks/pacemaker/resources/alert.rb
+++ b/chef/cookbooks/pacemaker/resources/alert.rb
@@ -1,0 +1,26 @@
+# Author:: Jacek Tomasiak
+# Cookbook Name:: pacemaker
+# Resource:: alert
+#
+# Copyright:: 2017, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :create, :update, :delete
+
+default_action :create
+
+attribute :name, kind_of: String, name_attribute: true
+attribute :handler, kind_of: String
+attribute :receiver, kind_of: String

--- a/chef/cookbooks/pacemaker/spec/fixtures/alert.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/alert.rb
@@ -1,0 +1,18 @@
+require_relative "../../libraries/pacemaker/alert"
+
+class Chef
+  module RSpec
+    module Pacemaker
+      module Config
+        ALERT = ::Pacemaker::Alert.new("alert1")
+        ALERT.handler = "handler.sh"
+        ALERT.receiver = "receiver-id"
+        ALERT.attrs_authoritative
+        ALERT_DEFINITION = <<'PCMK'.chomp
+alert alert1 handler.sh \
+         to receiver-id
+PCMK
+      end
+    end
+  end
+end

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/alert_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/alert_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+
+require_relative "../../../libraries/pacemaker/alert"
+require_relative "../../fixtures/alert"
+require_relative "../../helpers/cib_object"
+require_relative "../../helpers/meta_examples"
+
+describe Pacemaker::Alert do
+  let(:fixture) { Chef::RSpec::Pacemaker::Config::ALERT.dup }
+  let(:fixture_definition) do
+    Chef::RSpec::Pacemaker::Config::ALERT_DEFINITION
+  end
+
+  def object_type
+    "alert"
+  end
+
+  def pacemaker_object_class
+    Pacemaker::Alert
+  end
+
+  def fields
+    %w(name handler receiver)
+  end
+
+  it_should_behave_like "a CIB object"
+
+  describe "#definition" do
+    it "should return the definition string" do
+      expect(fixture.definition).to eq(fixture_definition)
+    end
+
+    it "should return a short definition string" do
+      alert = pacemaker_object_class.new("foo")
+      alert.definition = \
+        %(alert alert1 handler.sh to receiver-id)
+      expect(alert.definition).to eq(<<'PMCK'.chomp)
+alert alert1 handler.sh \
+         to receiver-id
+PMCK
+    end
+  end
+
+  describe "#parse_definition" do
+    before(:each) do
+      @parsed = pacemaker_object_class.new(fixture.name)
+      @parsed.definition = fixture_definition
+    end
+
+    it "should parse the handler" do
+      expect(@parsed.handler).to eq(fixture.handler)
+    end
+
+    it "should parse the receiver" do
+      expect(@parsed.receiver).to eq(fixture.receiver)
+    end
+  end
+end

--- a/chef/cookbooks/pacemaker/spec/providers/alert_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/providers/alert_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+require_relative "../helpers/non_runnable_resource"
+require_relative "../fixtures/alert"
+
+describe "Chef::Provider::PacemakerAlert" do
+  # for use inside examples:
+  let(:fixture) { Chef::RSpec::Pacemaker::Config::ALERT.dup }
+  # for use outside examples (e.g. when invoking shared_examples)
+  fixture = Chef::RSpec::Pacemaker::Config::ALERT.dup
+
+  def lwrp_name
+    "alert"
+  end
+
+  include_context "a Pacemaker LWRP with artificially constructed resource"
+
+  before(:each) do
+    @resource.handler fixture.handler.dup
+    @resource.receiver fixture.receiver.dup
+  end
+
+  def cib_object_class
+    Pacemaker::Alert
+  end
+
+  shared_examples "an updateable resource" do
+    include Chef::RSpec::Pacemaker::CIBObject
+
+    it "should modify the alert if the resource is changed" do
+      expected = fixture.dup
+      expected.handler = "handler2.sh"
+      expected_configure_cmd_args = [expected.reconfigure_command]
+      test_modify(expected_configure_cmd_args) do
+        @resource.handler expected.handler
+      end
+    end
+  end
+
+  describe ":create action" do
+    let(:action) { :create }
+    it_should_behave_like "an updateable resource"
+  end
+
+  describe ":update action" do
+    let(:action) { :update }
+    it_should_behave_like "an updateable resource"
+  end
+
+  it_should_behave_like "a non-runnable resource", fixture
+end


### PR DESCRIPTION
Pacemaker supports alert feature which can be used to attach scripts
to various cluster events. This commit exposes basic alerts to chef as
resources. Creating, updating and deleting is supported.