### PR TITLE
2-node clusters should have two_node: 1

### DIFF
--- a/chef/cookbooks/corosync/templates/default/corosync.conf.v2.erb
+++ b/chef/cookbooks/corosync/templates/default/corosync.conf.v2.erb
@@ -129,4 +129,10 @@ quorum {
 	# Enable and configure quorum subsystem (default: off)
 	# see also corosync.conf.5 and votequorum.5
 	provider: corosync_votequorum
+  <% if @members_v2.length <= 2 -%>
+	expected_votes: <%= @members_v2.length %>
+    <% if @members_v2.length == 2 -%>
+	two_node: 1
+    <% end -%>
+  <% end -%>
 }

--- a/chef/cookbooks/pacemaker/attributes/default.rb
+++ b/chef/cookbooks/pacemaker/attributes/default.rb
@@ -51,7 +51,7 @@ end
 default[:pacemaker][:founder] = nil
 default[:pacemaker][:is_remote] = false
 default[:pacemaker][:crm][:initial_config_file] = "/etc/corosync/crm-initial.conf"
-default[:pacemaker][:crm][:no_quorum_policy] = "ignore"
+default[:pacemaker][:crm][:no_quorum_policy] = "stop"
 # Should be longer than the systemd timeouts (defaults to 90s) so that
 # pacemaker only reacts when systemd is not helping anymore
 default[:pacemaker][:crm][:op_default_timeout] = 120

--- a/crowbar_framework/app/assets/javascripts/barclamps/pacemaker/application.js
+++ b/crowbar_framework/app/assets/javascripts/barclamps/pacemaker/application.js
@@ -225,7 +225,7 @@ function update_no_quorum_policy(evt, init) {
     if (evt.type == 'nodeListNodeUnallocated') { members -= 1; }
   }
 
-  if (members > 2) {
+  if (members > 1) {
     if (was_forced_policy) {
       no_quorum_policy_el.val(non_forced_policy);
       no_quorum_policy_el.removeData('non-forced');


### PR DESCRIPTION
This fixes https://bugzilla.suse.com/show_bug.cgi?id=981056

On pacemaker clusters of 2-nodes, we should set the
corosync quorum conf to use `two_node: 1` rather than
force the use of `no-quorum-policy=ignore` in pacemaker.

The corosync `two_nodes:1` tells corosync that it only
needs 1 vote for quorum instead of 2.
Before this patch we'd force these clusters to use the ignore
policy when the cluster was being defined via the
crowbar web ui (via javascript) which lead to
bugs like https://bugzilla.suse.com/show_bug.cgi?id=981056.

This patch is removing the javascript function that is
enforcing this behaviour completely as now that 2-node
clusters behave as expected, users should get a choice in
what no-quorum-policy they want to use.