### PR TITLE
pacemaker: Made alert receiver optional

### DIFF
--- a/chef/cookbooks/pacemaker/libraries/pacemaker/alert.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/alert.rb
@@ -13,7 +13,7 @@ module Pacemaker
     end
 
     def parse_definition
-      unless @definition =~ /\A#{self.class.object_type} (\S+) (\S+)[\\\s]+to (\S+)/
+      unless @definition =~ /\A#{self.class.object_type} (\S+) (\S+)(?:[\\\s]+to (\S+))?/
         raise Pacemaker::CIBObject::DefinitionParseError, \
               "Couldn't parse definition '#{@definition}'"
       end
@@ -26,7 +26,8 @@ module Pacemaker
 
     def definition_from_attributes
       str = "#{self.class.object_type} #{name} #{handler}"
-      str << continuation_line("to #{receiver}") unless receiver.empty?
+      str << continuation_line("to #{receiver}") unless receiver.nil? || receiver.empty?
+      str
     end
 
     def self.description

--- a/chef/cookbooks/pacemaker/spec/fixtures/alert.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/alert.rb
@@ -6,10 +6,15 @@ class Chef
       module Config
         ALERT = ::Pacemaker::Alert.new("alert1")
         ALERT.handler = "handler.sh"
-        ALERT.receiver = "receiver-id"
         ALERT.attrs_authoritative
-        ALERT_DEFINITION = <<'PCMK'.chomp
-alert alert1 handler.sh \
+        ALERT_DEFINITION = "alert alert1 handler.sh".freeze
+
+        ALERT_WITH_TO = ::Pacemaker::Alert.new("alert2")
+        ALERT_WITH_TO.handler = "handler2.sh"
+        ALERT_WITH_TO.receiver = "receiver-id"
+        ALERT_WITH_TO.attrs_authoritative
+        ALERT_DEFINITION_WITH_TO = <<'PCMK'.chomp
+alert alert2 handler2.sh \
          to receiver-id
 PCMK
       end

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/alert_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/alert_spec.rb
@@ -10,6 +10,10 @@ describe Pacemaker::Alert do
   let(:fixture_definition) do
     Chef::RSpec::Pacemaker::Config::ALERT_DEFINITION
   end
+  let(:fixture_with_to) { Chef::RSpec::Pacemaker::Config::ALERT_WITH_TO.dup }
+  let(:fixture_definition_with_to) do
+    Chef::RSpec::Pacemaker::Config::ALERT_DEFINITION_WITH_TO
+  end
 
   def object_type
     "alert"
@@ -30,7 +34,17 @@ describe Pacemaker::Alert do
       expect(fixture.definition).to eq(fixture_definition)
     end
 
+    it "should return the definition string (with to)" do
+      expect(fixture_with_to.definition).to eq(fixture_definition_with_to)
+    end
+
     it "should return a short definition string" do
+      alert = pacemaker_object_class.new("foo")
+      alert.definition = "alert alert1 handler.sh"
+      expect(alert.definition).to eq("alert alert1 handler.sh")
+    end
+
+    it "should return a short definition string (with to)" do
       alert = pacemaker_object_class.new("foo")
       alert.definition = \
         %(alert alert1 handler.sh to receiver-id)
@@ -45,14 +59,18 @@ PMCK
     before(:each) do
       @parsed = pacemaker_object_class.new(fixture.name)
       @parsed.definition = fixture_definition
+
+      @parsed_with_to = pacemaker_object_class.new(fixture_with_to.name)
+      @parsed_with_to.definition = fixture_definition_with_to
     end
 
     it "should parse the handler" do
       expect(@parsed.handler).to eq(fixture.handler)
+      expect(@parsed_with_to.handler).to eq(fixture_with_to.handler)
     end
 
     it "should parse the receiver" do
-      expect(@parsed.receiver).to eq(fixture.receiver)
+      expect(@parsed_with_to.receiver).to eq(fixture_with_to.receiver)
     end
   end
 end

--- a/chef/cookbooks/pacemaker/spec/providers/alert_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/providers/alert_spec.rb
@@ -5,9 +5,9 @@ require_relative "../fixtures/alert"
 
 describe "Chef::Provider::PacemakerAlert" do
   # for use inside examples:
-  let(:fixture) { Chef::RSpec::Pacemaker::Config::ALERT.dup }
+  let(:fixture) { Chef::RSpec::Pacemaker::Config::ALERT_WITH_TO.dup }
   # for use outside examples (e.g. when invoking shared_examples)
-  fixture = Chef::RSpec::Pacemaker::Config::ALERT.dup
+  fixture = Chef::RSpec::Pacemaker::Config::ALERT_WITH_TO.dup
 
   def lwrp_name
     "alert"
@@ -29,7 +29,7 @@ describe "Chef::Provider::PacemakerAlert" do
 
     it "should modify the alert if the resource is changed" do
       expected = fixture.dup
-      expected.handler = "handler2.sh"
+      expected.handler = "handlernew.sh"
       expected_configure_cmd_args = [expected.reconfigure_command]
       test_modify(expected_configure_cmd_args) do
         @resource.handler expected.handler


### PR DESCRIPTION
The receiver/recipient of alerts is not mandatory. Modified wrapper classes to support such cases.