### PR TITLE
[4.0] crowbar-pacemaker: Deploy ssh keys before joining

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -91,6 +91,10 @@ end
 
 node.save if dirty
 
+# make sure all ssh keys are deployed before joining the cluster to allow
+# alert handlers to ssh to this node if needed.
+include_recipe "provisioner::keys"
+
 include_recipe "pacemaker::default"
 
 # Set up authkey for pacemaker remotes (different to corosync authkey)


### PR DESCRIPTION
Authorized keys need to be deployed to nodes before joining cluster
so that the founder can ssh to the new node from alert handler.

(cherry picked from commit 6d4b0667f7f3f2cd48a4b6735c8f84e1c0368c7d)

backport of #285 

requires https://github.com/crowbar/crowbar-core/pull/1457