### PR TITLE
pacemaker: Change default for clone_stateless_services to false

### DIFF
--- a/chef/data_bags/crowbar/template-pacemaker.json
+++ b/chef/data_bags/crowbar/template-pacemaker.json
@@ -54,7 +54,7 @@
         "admin_name": "",
         "public_name": ""
       },
-      "clone_stateless_services": true
+      "clone_stateless_services": false
     }
   },
   "deployment": {


### PR DESCRIPTION
As a reminder, with this option set to false, pacemaker will not manage
stateless services such as OpenStack API services -- instead, systemd
will restart them on crash.

This works rather well, and since we never went to the point where we
had some OCF resource agent for such services, and only use a systemd
resource agent, the benefit of pacemaker is too limited. Reducing
complexity, and converging with the Ardana deployment is therefore more
interesting here.