### PR TITLE
Disallow DRBD for new deployments

### DIFF
--- a/crowbar_framework/app/assets/javascripts/barclamps/pacemaker/application.js
+++ b/crowbar_framework/app/assets/javascripts/barclamps/pacemaker/application.js
@@ -242,40 +242,6 @@ function update_no_quorum_policy(evt, init) {
   }
 }
 
-function update_drbd_enabled(evt, init) {
-  var drbd_enabled_el = $('#drbd_enabled');
-  var non_forced_enabled = drbd_enabled_el.data('non-forced');
-  var was_forced_enabled = drbd_enabled_el.data('is-forced');
-  var members = $('#pacemaker-cluster-member').children().length;
-
-  if (non_forced_enabled == undefined) {
-    non_forced_enabled = "false";
-  }
-
-  if (evt != undefined) {
-    // 'nodeListNodeAllocated' is fired after the element has been added, so
-    // nothing to do. However, 'nodeListNodeUnallocated' is fired before the
-    // element is removed, so we need to fix the count.
-    if (evt.type == 'nodeListNodeUnallocated') { members -= 1; }
-  }
-
-  if (members == 2) {
-    if (was_forced_enabled) {
-      drbd_enabled_el.val(non_forced_enabled);
-      drbd_enabled_el.removeData('non-forced');
-    }
-    drbd_enabled_el.data('is-forced', false)
-    drbd_enabled_el.removeAttr('disabled');
-  } else {
-    if (!init && !was_forced_enabled) {
-      drbd_enabled_el.data('non-forced', drbd_enabled_el.val());
-    }
-    drbd_enabled_el.data('is-forced', true)
-    drbd_enabled_el.val("false");
-    drbd_enabled_el.attr('disabled', 'disabled');
-  }
-}
-
 function cb_corosync_ring_delete()
 {
   ring_index = $(this).data("ringid");
@@ -362,15 +328,12 @@ $(document).ready(function($) {
   // $('#stonith_per_node_container') breaks the per-node table :/
   $(document).on('nodeListNodeAllocated', function(evt, data) {
     update_no_quorum_policy(evt, false)
-    update_drbd_enabled(evt, false)
   });
   $(document).on('nodeListNodeUnallocated', function(evt, data) {
     update_no_quorum_policy(evt, false)
-    update_drbd_enabled(evt, false)
   });
 
   update_no_quorum_policy(undefined, true)
-  update_drbd_enabled(undefined, true)
 
   if ($.queryString.attr_raw != "true") {
     redisplay_rings();

--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -718,9 +718,17 @@ class PacemakerService < ServiceObject
     end
 
     if proposal["attributes"][@bc_name]["drbd"]["enabled"]
-      validation_error I18n.t(
-        "barclamp.#{bc_name}.validation.drbd"
-      ) if members.length != 2
+      proposal_id = proposal["id"].gsub("#{@bc_name}-", "")
+      proposal_object = Proposal.where(barclamp: @bc_name, name: proposal_id).first
+      if proposal_object.nil? || !proposal_object.active_status?
+        validation_error I18n.t(
+          "barclamp.#{@bc_name}.validation.no_new_drbd"
+        )
+      else
+        validation_error I18n.t(
+          "barclamp.#{bc_name}.validation.drbd"
+        ) if members.length != 2
+      end
     end
 
     nodes = NodeObject.find("roles:provisioner-server")

--- a/crowbar_framework/app/views/barclamp/pacemaker/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/pacemaker/_edit_attributes.html.haml
@@ -119,15 +119,6 @@
 
     %fieldset
       %legend
-        = t(".drbd_header")
-
-      .alert.alert-info
-        = t(".drbd.info")
-
-      = boolean_field %w(drbd enabled)
-
-    %fieldset
-      %legend
         = t(".haproxy_header")
 
       .alert.alert-info

--- a/crowbar_framework/config/locales/pacemaker/en.yml
+++ b/crowbar_framework/config/locales/pacemaker/en.yml
@@ -25,10 +25,6 @@ en:
   barclamp:
     pacemaker:
       edit_attributes:
-        drbd_header: 'DRBD'
-        drbd:
-          info: 'Using DRBD for replicated storage is an alternative to using shared storage for high availability of services like database and RabbitMQ. This requires the cluster to have two nodes only, as well as one dedicated disk on each cluster member.'
-          enabled: 'Prepare cluster for DRBD'
         haproxy_header: 'HAProxy'
         haproxy:
           ssl_info:

--- a/crowbar_framework/config/locales/pacemaker/en.yml
+++ b/crowbar_framework/config/locales/pacemaker/en.yml
@@ -146,6 +146,7 @@ en:
         smtp_server: 'Invalid SMTP server for mail notifications.'
         sender_address: 'Invalid sender address for mail notifications.'
         recipient_address: 'Invalid recipient address for mail notifications.'
+        no_new_drbd: 'DRBD is not allowed for new deployments since services can not be configured to use it anymore.'
         drbd: 'Setting up DRBD requires a cluster of two nodes.'
         ha_repo: 'The SLE HA repositories have not been setup.'
         transport_value: 'Invalid transport value: %{transport}.'


### PR DESCRIPTION
DRBD is only useful for PostgreSQL HA and unclustered RabbitMQ HA, which
are both features we want to disallow for new deployments. So DRBD has
no real use in new deployments.

Depends on https://github.com/crowbar/crowbar-openstack/pull/1545