### PR TITLE
Update corosync configuration correctly and in time when adding a new cluster node

### DIFF
--- a/chef/cookbooks/corosync/recipes/config.rb
+++ b/chef/cookbooks/corosync/recipes/config.rb
@@ -86,6 +86,14 @@ template "/etc/corosync/corosync.conf" do
   # via corosync-cfgtool -R.
 end
 
+corosync_action = :delayed
+
+if node[:crowbar_wall][:cluster_size_changed]
+  corosync_action = :immediately
+  node.set[:crowbar_wall][:cluster_size_changed] = false
+  node.save
+end
+
 execute "reload corosync.conf" do
   # corosync-cfgtool -R reloads the configuration across ALL the nodes in the
   # cluster - each reloading its own local configuration file. This means that
@@ -101,5 +109,5 @@ execute "reload corosync.conf" do
   user "root"
   group "root"
   action :nothing
-  subscribes :run, "template[/etc/corosync/corosync.conf]", :delayed
+  subscribes :run, "template[/etc/corosync/corosync.conf]", corosync_action
 end

--- a/chef/cookbooks/crowbar-pacemaker/recipes/mutual_ssh.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/mutual_ssh.rb
@@ -24,7 +24,8 @@
 
 cluster_access_keys = []
 
-CrowbarPacemakerHelper.cluster_nodes(node).each do |cluster_node|
+node[:pacemaker][:elements]["pacemaker-cluster-member"].each do |node_name|
+  cluster_node = search(:node, "name:#{node_name}").first
   pkey = nil
   if cluster_node[:crowbar][:ssh]
     pkey = cluster_node[:crowbar][:ssh][:root_pub_key]


### PR DESCRIPTION
When a new node is added to the cluster, waiting for corosync reload after the end of chef-client run (`:delayed` action) is too late.

With current implementation of pacemaker sync marks, crm_attribute calls are used and they fail when corosync does not have the full information about all its nodes.

See https://github.com/crowbar/crowbar-ha/pull/305 for (partially) alternative take 