### PR TITLE
Update corosync configuration correctly and in time when adding a new cluster node

### DIFF
--- a/chef/cookbooks/corosync/recipes/config.rb
+++ b/chef/cookbooks/corosync/recipes/config.rb
@@ -86,6 +86,14 @@ template "/etc/corosync/corosync.conf" do
   # via corosync-cfgtool -R.
 end
 
+corosync_action = :delayed
+
+if node[:crowbar_wall][:cluster_members_changed]
+  corosync_action = :immediately
+  node.set[:crowbar_wall][:cluster_members_changed] = false
+  node.save
+end
+
 execute "reload corosync.conf" do
   # corosync-cfgtool -R reloads the configuration across ALL the nodes in the
   # cluster - each reloading its own local configuration file. This means that
@@ -101,5 +109,5 @@ execute "reload corosync.conf" do
   user "root"
   group "root"
   action :nothing
-  subscribes :run, "template[/etc/corosync/corosync.conf]", :delayed
+  subscribes :run, "template[/etc/corosync/corosync.conf]", corosync_action
 end

--- a/chef/cookbooks/pacemaker/spec/helpers/provider.rb
+++ b/chef/cookbooks/pacemaker/spec/helpers/provider.rb
@@ -15,6 +15,9 @@ shared_context "a Pacemaker LWRP" do
     }
     @chef_run = ::ChefSpec::Runner.new(runner_opts)
     @node = @chef_run.node
+    @node.normal[:pacemaker] ||= {}
+    @node.normal[:pacemaker][:elements] ||= {}
+    @node.normal[:pacemaker][:elements]["pacemaker-cluster-member"] = {}
   end
 
   def converge

--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -384,9 +384,11 @@ class PacemakerService < ServiceObject
     member_nodes = members.map { |n| NodeObject.find_node_by_name n }
     remotes = attributes["elements"]["pacemaker-remote"] || []
     remote_nodes = remotes.map { |n| NodeObject.find_node_by_name n }
+    old_members = []
 
     founder_name = nil
     founder = nil
+    cluster_members_changed = false
 
     # elect a founder
     unless members.empty?
@@ -397,13 +399,16 @@ class PacemakerService < ServiceObject
         old_founder_name = old_role.default_attributes["pacemaker"]["founder"]
         founder_name = old_founder_name if members.include?(old_founder_name)
 
+        old_members = old_attributes["elements"]["pacemaker-cluster-member"]
+
         # the founder from the old role is not there anymore; let's promote
         # another node to founder, so we get the same authkey
         if founder_name.nil?
-          old_members = old_attributes["elements"]["pacemaker-cluster-member"]
           old_members = old_members.select { |n| members.include? n }
           founder_name = old_members.first
         end
+
+        cluster_members_changed = members.sort != old_members.sort
       end
 
       # Still nothing, there are two options:
@@ -462,6 +467,8 @@ class PacemakerService < ServiceObject
       member_node[:drbd] ||= {}
       member_node[:drbd][:local_node_id] = is_founder ? 0 : 1
       member_node[:drbd][:remote_node_id] = is_founder ? 1 : 0
+      member_node[:crowbar_wall][:cluster_members_changed] =
+        cluster_members_changed && old_members.include?(member_node.name)
       member_node.save
     end
 


### PR DESCRIPTION
When a new node is added to the cluster, waiting for corosync reload after the end of chef-client run (:delayed action) is too late.

With current implementation of pacemaker sync marks, crm_attribute calls are used and they fail when corosync does not have the full information about all its nodes. So we must somehow extend the first synchronization that happens before the sync marks mechanism is used.


~Alternative solution to https://github.com/crowbar/crowbar-ha/pull/303 , this one looks cleaner~

Also required for adding cluster node: https://github.com/crowbar/crowbar-openstack/pull/1583