### PR TITLE
[4.0] pacemaker: added support for op defaults

### DIFF
--- a/chef/data_bags/crowbar/migrate/pacemaker/105_op_defaults.rb
+++ b/chef/data_bags/crowbar/migrate/pacemaker/105_op_defaults.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["op_defaults"] = ta["op_defaults"] unless a.key? "op_defaults"
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("op_defaults") unless ta.key? "op_defaults"
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-pacemaker.json
+++ b/chef/data_bags/crowbar/template-pacemaker.json
@@ -54,14 +54,19 @@
         "admin_name": "",
         "public_name": ""
       },
-      "clone_stateless_services": true
+      "clone_stateless_services": true,
+      "op_defaults": {
+        "monitor": {
+          "on-fail": ""
+        }
+      }
     }
   },
   "deployment": {
     "pacemaker": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 104,
+      "schema-revision": 105,
       "element_states": {
         "pacemaker-cluster-member"    : [ "readying", "ready", "applying" ],
         "hawk-server"                 : [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-pacemaker.schema
+++ b/chef/data_bags/crowbar/template-pacemaker.schema
@@ -141,7 +141,20 @@
                 "public_name": { "type": "str", "required": true }
               }
             },
-            "clone_stateless_services": { "type": "bool", "required": true }
+            "clone_stateless_services": { "type": "bool", "required": true },
+            "op_defaults": {
+              "type": "map",
+              "required": true,
+              "mapping": {
+                "monitor": {
+                  "type": "map",
+                  "required": true,
+                  "mapping": {
+                    "on-fail": { "type": "str", "required": true, "pattern": "/^ignore$|^block$|^stop$|^restart$|^fence$|^standby$|^$/"}
+                  }
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
backport of https://github.com/crowbar/crowbar-ha/pull/297

We needed to add a default option for the pacemaker op defaults. In
particular we are interested in offering a default for "op monitor
on-fail" action.

Pacemaker does not offer a configuration option to offer such defaults
for all resources. There's a way to do it for a single resource with
rsc_defaults, but that is not our case. Also with Pacemaker you could
link one resource operations to another one with 'id-ref', but in that
case if you modify the reference resource it will cascade changes to all
other resourced.

This approach allows to store in the pacemaker barclamp a default for
op. In this case we are only interested in op monitor but could easily
be extended later on.

The primitive will read that value from the founder node and set it to
all 'op monitor on-fail' actions. Should the user had configured
manually the defaults (editing the barclamp), then those manually
configured values will prevail.

(cherry picked from commit e3a6e4c1445986e9688c50fc065afea5a56de71e)