### PR TITLE
[4.0] prevent systemd from owning Pacemaker-controlled services (bsc#980341)

### DIFF
--- a/chef/cookbooks/pacemaker/recipes/default.rb
+++ b/chef/cookbooks/pacemaker/recipes/default.rb
@@ -26,6 +26,13 @@ node[:pacemaker][:platform][:packages].each do |pkg|
   package pkg
 end
 
+file "/etc/sysconfig/pacemaker" do
+  content "SYSTEMD_NO_WRAP=1"
+  owner "root"
+  mode "0644"
+  action :create
+end
+
 if Chef::Config[:solo]
   unless ENV["RSPEC_RUNNING"]
     Chef::Application.fatal! \


### PR DESCRIPTION
Backport of #174 to SOC7.

Pacemaker has a problem with old-style LSB init scripts on SLE12.  This is because when invoking an action such as `start` or `stop` on these init scripts, they first source `/etc/rc.status`, which causes a redirect to `systemctl`, which finally invokes the init script again, this time with `SYSTEMD_NO_WRAP` set.

So when we define an `lsb:*` primitive resource inside Pacemaker, the result is that when it starts the service, systemd thinks that *it* started the service and is therefore its owner and hence responsible for shutting it down when the system is being shut down.  This can have disastrous results - for example on system shutdown, systemd might try to stop drbd before or in parallel with other services such as Pacemaker which would have stopped it cleanly in the correct order, only after shutting down all the resources which depend on it (some of which could be on other nodes in the cluster).

The correct behaviour would be for systemd not to touch services started by Pacemaker, ever.  In fact this correct behaviour is already implemented for `systemd:*` resources, by placing a suitable override into `/run/systemd/system/foo.service.d/50-pacemaker.conf` so that systemd knows not to touch service `foo` itself.  But we need something similar for LSB resources.

Since the systemd wrapping mechanism is only used by SUSE, this needs to be a SUSE-specific solution.  For now we can achieve it by setting `SYSTEMD_NO_WRAP` in `/etc/sysconfig/pacemaker`, so that it will be inherited in the environment of the lrmd process, and from there into any init scripts which lrmd spawns.  As a result these services should be started without systemd being aware.

https://bugzilla.suse.com/show_bug.cgi?id=980341

(cherry picked from commit acc98269120882ed53f4259206d1efcff56a4a01)