### PR TITLE
[4.0] haproxy: increased SSL stick table to 100k

### DIFF
--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -47,7 +47,7 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
 
     <% if content[:use_ssl] # http://www.haproxy.com/blog/maintain-affinity-based-on-ssl-session-id/ -%>
 	# maximum SSL session ID length is 32 bytes.
-	stick-table type binary len 32 size 30k expire <%= content[:stick] ? content[:stick][:expire] : "32m" %>
+	stick-table type binary len 32 size 100k expire <%= content[:stick] ? content[:stick][:expire] : "32m" %>
 
 	acl clienthello req_ssl_hello_type 1
 	acl serverhello rep_ssl_hello_type 2


### PR DESCRIPTION
Backport of https://github.com/crowbar/crowbar-ha/pull/313 to SOC7.

We found that SSL stick tables in haproxy can get full on big
deployments. We are increasing the stick table from 30k to 100k, which
is also the size the other stick tables have.

(cherry picked from commit ba7e51a4d63316b1b01a5aad3d8a0749753bc5f2)