### PR TITLE
[4.0] pacemaker: allow multiple meta parameters (bsc#1093898)

### DIFF
--- a/chef/cookbooks/pacemaker/libraries/pacemaker/resource.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/resource.rb
@@ -77,7 +77,7 @@ module Pacemaker
 
     # This method extracts the list of Hash from the params / meta / op
     # matching the requested data_type. This should never return more than one
-    # result, unless we're looking for an op.
+    # result, unless we're looking for an op or meta.
     def self.extract_hash(obj_definition, data_type)
       results = find_all_to_extract(obj_definition, data_type).map do |string|
         extract_hash_from_one(string, data_type)
@@ -87,6 +87,8 @@ module Pacemaker
         {}
       elsif results.length == 1
         results[0]
+      elsif data_type =~ /^meta$/
+        results.reduce({}, :merge)
       else
         if data_type !~ /^op (.*)$/
           raise "Many results when extracting hash for #{data_type} from "\

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/resource_spec.rb
@@ -56,5 +56,27 @@ describe Pacemaker::Resource do
       no_meta = fixture.definition.gsub(/\bmeta .*\\$/, "meta \\")
       expect(fixture.class.extract_hash(no_meta, "meta")).to eq({})
     end
+
+    it "should extract multiple joined meta" do
+      multi_meta = fixture.definition.gsub(
+        /\bmeta .*\\$/,
+        "meta is-managed=\"true\" target-role=\"Started\" \\"
+      )
+      expect(fixture.class.extract_hash(multi_meta, "meta")).to eq(
+        "is-managed" => "true",
+        "target-role" => "Started"
+      )
+    end
+
+    it "should extract multiple separated meta" do
+      multi_meta = fixture.definition.gsub(
+        /\bmeta .*\\$/,
+        "meta is-managed=\"true\" \\\nmeta target-role=\"Started\" \\"
+      )
+      expect(fixture.class.extract_hash(multi_meta, "meta")).to eq(
+        "is-managed" => "true",
+        "target-role" => "Started"
+      )
+    end
   end
 end


### PR DESCRIPTION
Based on 4e944918b7df65a25b8737c41ba5ee5558f9c6f1.

There is the chance that multiple 'meta' parameters appear in
a CIB resource. This produce an exception in 'extract_hash`
method.

For example, in bsc#1093898 a client provide a crm configuration
with this layout:

```
primitive neutron-ha-tool ocf:openstack:neutron-ha-tool \
        params os_auth_url="http://cluster-Controllerha.cloud.orange:5000/v2.0/" os_insecure=false os_region_name=RegionOne os_tenant_name=admin os_username=admin \
        op monitor interval=10s \
        op start interval=0 timeout=1800s \
        meta target-role=Started \
        meta maintenance=false
```

This patch allows multiple 'meta' parameter in the result.

(cherry picked from commit bd7c014c6dc7811fba959e7fe880365310d359c1)