### PR TITLE
[4.0] Populate the node names when drbd is enabled

### DIFF
--- a/chef/data_bags/crowbar/migrate/pacemaker/106_populate_drbd_nodes.rb
+++ b/chef/data_bags/crowbar/migrate/pacemaker/106_populate_drbd_nodes.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  if a["drbd"]["enabled"]
+    a["drbd"]["nodes"] = d["elements"]["pacemaker-cluster-member"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["drbd"].delete("nodes")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-pacemaker.json
+++ b/chef/data_bags/crowbar/template-pacemaker.json
@@ -66,7 +66,7 @@
     "pacemaker": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 105,
+      "schema-revision": 106,
       "element_states": {
         "pacemaker-cluster-member"    : [ "readying", "ready", "applying" ],
         "hawk-server"                 : [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-pacemaker.schema
+++ b/chef/data_bags/crowbar/template-pacemaker.schema
@@ -130,7 +130,8 @@
               "required": true,
               "mapping": {
                 "enabled": { "type": "bool", "required": true },
-                "shared_secret": { "type": "str", "required": true }
+                "shared_secret": { "type": "str", "required": true },
+                "nodes": { "type": "seq", "sequence": [ { "type": "str" } ] }
               }
             },
             "haproxy": {


### PR DESCRIPTION
To allow us to set up location constraints for the database and rabbitmq
roles when drbd is enabled and we then grow the cluster to 3 nodes to allow
us to migrate to MariaDB, populate what the nodes are so we can force
DRBD related cluster roles onto those nodes only.

This currently doesn't work -- the intent is [:drbd][:nodes] will be set to the two nodes in the cluster and then not change when a third cluster member is added.