### PR TITLE
[4.0] DRBD: fix when reinstall node

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/providers/drbd_create_internal.rb
+++ b/chef/cookbooks/crowbar-pacemaker/providers/drbd_create_internal.rb
@@ -45,7 +45,7 @@ action :create do
       end.run_action(:install)
     end
 
-    next if resource["configured"]
+    next if resource["configured"] == node.crowbar.state_debug.installed
 
     lvm_logical_volume resource_name do
       group new_resource.lvm_group
@@ -64,7 +64,7 @@ action :create do
     end.run_action(:create)
 
     # we know we have to save due to the "next" earlier on
-    node.set["drbd"]["rsc"][resource_name]["configured"] = true
+    node.set["drbd"]["rsc"][resource_name]["configured"] = node.crowbar.state_debug.installed
     node.save
   end
 


### PR DESCRIPTION
When a node is reinstalled the DRBD resources don't are configured
because of the node attribute drbd.rsc.<resource_name>.configured
is marked as true, and the setup is skiped.

This solution store a counter instead of true and false. In each
reinstalation this counter is increased by crowbar. So checking
if the current reinstalation number is equal to the configured
stored in the node attributes it can skip when it's necesary
and setup the DRBD resources when it's needed.