### PR TITLE
[4.0] drbd: Add switch to short circuit cluster size check

### DIFF
--- a/chef/data_bags/crowbar/migrate/pacemaker/106_allow_larger_cluster.rb
+++ b/chef/data_bags/crowbar/migrate/pacemaker/106_allow_larger_cluster.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a["drbd"].key? "allow_larger_cluster"
+    a["drbd"]["allow_larger_cluster"] = ta["drbd"]["allow_larger_cluster"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta["drbd"].key? "allow_larger_cluster"
+    a["drbd"].delete("allow_larger_cluster")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-pacemaker.json
+++ b/chef/data_bags/crowbar/template-pacemaker.json
@@ -48,7 +48,8 @@
       },
       "drbd": {
         "enabled": false,
-        "shared_secret": ""
+        "shared_secret": "",
+        "allow_larger_cluster": false
       },
       "haproxy": {
         "admin_name": "",
@@ -66,7 +67,7 @@
     "pacemaker": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 105,
+      "schema-revision": 106,
       "element_states": {
         "pacemaker-cluster-member"    : [ "readying", "ready", "applying" ],
         "hawk-server"                 : [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-pacemaker.schema
+++ b/chef/data_bags/crowbar/template-pacemaker.schema
@@ -130,7 +130,8 @@
               "required": true,
               "mapping": {
                 "enabled": { "type": "bool", "required": true },
-                "shared_secret": { "type": "str", "required": true }
+                "shared_secret": { "type": "str", "required": true },
+                "allow_larger_cluster": { "type": "bool", "required": true }
               }
             },
             "haproxy": {

--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -724,7 +724,8 @@ class PacemakerService < ServiceObject
       ) if smtp_settings["to"].blank?
     end
 
-    if proposal["attributes"][@bc_name]["drbd"]["enabled"]
+    drbd_attrs = proposal["attributes"][@bc_name]["drbd"]
+    if drbd_attrs["enabled"] && !drbd_attrs["allow_larger_cluster"]
       validation_error I18n.t(
         "barclamp.#{bc_name}.validation.drbd"
       ) if members.length != 2


### PR DESCRIPTION
Currently, DRBD enabled clusters are forced to be only two nodes. To
fascitate upgrades from SOC7 to Cloud 8, we need to switching from
PostgreSQL to MariaDB with Galera, which requires three node clusters at
a minimum.