### PR TITLE
[5.0] crowbar-pacemaker: Cluster member SSH key improvements

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -93,6 +93,8 @@ node.save if dirty
 
 # make sure all ssh keys are deployed before joining the cluster to allow
 # alert handlers to ssh to this node if needed.
+# Also include each member of the cluster so they can communitcate or rsync if necessary.
+include_recipe "crowbar-pacemaker::mutual_ssh"
 include_recipe "provisioner::keys"
 
 include_recipe "pacemaker::default"
@@ -115,7 +117,6 @@ end
 
 include_recipe "crowbar-pacemaker::attributes"
 include_recipe "crowbar-pacemaker::maintenance-mode"
-include_recipe "crowbar-pacemaker::mutual_ssh"
 
 include_recipe "crowbar-pacemaker::openstack"
 


### PR DESCRIPTION
When adding a new node to the cluster the SSH keys of the other cluster
members aren't pushed to the new node until the second chef-client run.

'crowbar-pacemaker::mutual_ssh' only gathers the SSH keys and places
them in the correct location for 'provisioner::keys' to find on next run.
This patch switches this order and makes sure
'crowbar-pacemaker::mutual_ssh' runs before 'provisioner::keys' so the
ssh keys gets inserted into authorized_keys on the same chef-client run
as updating the pacemaker proposal.

Why is this important. When increasing the cluster, the original members
are put into maintenance mode. While updating other OpenStack
services all API calls will be going through the new member. If running
keystone with fernet keys the keystone calls will fail due to the
keys having not been rsynced to the new node. Further, any attempts to
rsync the fernet directory will fail until the SSH keys are placed on
the node.

(cherry picked from commit ec79f3ae6fc92a9e000e5bf3aa76290c1828a20c)