### PR TITLE
Adding a node into DRBD cluster

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/helpers.rb
@@ -37,6 +37,13 @@ module CrowbarPacemakerHelper
     ["prepare-os-upgrade", "done_os_upgrade"].include? upgrade_step
   end
 
+  # Does the node have DRBD setup? This is needed when we want to find out
+  # if a node in drbd-enabled cluster has really DRBD nor not.
+  def self.drbd_node?(node)
+    return false unless cluster_enabled?(node)
+    node[:pacemaker][:drbd] && node[:pacemaker][:drbd][:nodes] && node[:pacemaker][:drbd][:nodes].include?(node[:fqdn])
+  end
+
   # Returns the number of corosync (or non-remote) nodes in the cluster.
   def self.num_corosync_nodes(node)
     return 0 unless cluster_enabled?(node)

--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -121,5 +121,9 @@ include_recipe "crowbar-pacemaker::maintenance-mode"
 include_recipe "crowbar-pacemaker::openstack"
 
 if node[:pacemaker][:drbd][:enabled]
-  include_recipe "crowbar-pacemaker::drbd_setup"
+  if CrowbarPacemakerHelper.drbd_node?(node)
+    include_recipe "crowbar-pacemaker::drbd_setup"
+  else
+    Chef::Log.info("Not creating DRBD setup for this node")
+  end
 end

--- a/chef/data_bags/crowbar/migrate/pacemaker/107_populate_drbd_nodes.rb
+++ b/chef/data_bags/crowbar/migrate/pacemaker/107_populate_drbd_nodes.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  if a["drbd"]["enabled"]
+    a["drbd"]["nodes"] = d["elements"]["pacemaker-cluster-member"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["drbd"].delete("nodes")
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/pacemaker/107_populate_drbd_nodes.rb
+++ b/chef/data_bags/crowbar/migrate/pacemaker/107_populate_drbd_nodes.rb
@@ -1,7 +1,15 @@
 def upgrade(ta, td, a, d)
   if a["drbd"]["enabled"]
     a["drbd"]["nodes"] = d["elements"]["pacemaker-cluster-member"]
+
+    d["elements"]["pacemaker-cluster-member"].each do |name|
+      node = Node.find_by_name(name)
+      next if node.nil? || !node[:pacemaker][:drbd][:enabled]
+      node[:pacemaker][:attributes]["drbd-controller"] = true
+      node.save
+    end
   end
+
   return a, d
 end
 

--- a/chef/data_bags/crowbar/template-pacemaker.json
+++ b/chef/data_bags/crowbar/template-pacemaker.json
@@ -67,7 +67,7 @@
     "pacemaker": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 106,
+      "schema-revision": 107,
       "element_states": {
         "pacemaker-cluster-member"    : [ "readying", "ready", "applying" ],
         "hawk-server"                 : [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-pacemaker.schema
+++ b/chef/data_bags/crowbar/template-pacemaker.schema
@@ -131,7 +131,8 @@
               "mapping": {
                 "enabled": { "type": "bool", "required": true },
                 "shared_secret": { "type": "str", "required": true },
-                "allow_larger_cluster": { "type": "bool", "required": true }
+                "allow_larger_cluster": { "type": "bool", "required": true },
+                "nodes": { "type": "seq", "sequence": [ { "type": "str" } ] }
               }
             },
             "haproxy": {

--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -477,6 +477,9 @@ class PacemakerService < ServiceObject
       member_node[:pacemaker] ||= {}
       member_node[:pacemaker][:drbd] ||= {}
       member_node[:pacemaker][:drbd][:nodes] = drbd_nodes
+      member_node[:pacemaker][:attributes] ||= {}
+      member_node[:pacemaker][:attributes]["drbd-controller"] =
+        drbd_nodes.include?(member_node.name)
       member_node[:crowbar_wall][:cluster_members_changed] =
         cluster_members_changed && old_members.include?(member_node.name)
       member_node.save

--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -461,12 +461,22 @@ class PacemakerService < ServiceObject
     role.default_attributes["drbd"]["common"]["net"] ||= {}
     role.default_attributes["drbd"]["common"]["net"]["shared_secret"] = \
       role.default_attributes["pacemaker"]["drbd"]["shared_secret"]
+    if member_nodes.length == 2
+      drbd_nodes = member_nodes.map(&:name)
+    elsif founder[:pacemaker].key?("drbd") && founder[:pacemaker][:drbd].key?("nodes")
+      drbd_nodes = founder[:pacemaker][:drbd][:nodes]
+    else
+      drbd_nodes = []
+    end
     # set node IDs for drbd metadata
     member_nodes.each do |member_node|
       is_founder = (member_node.name == founder_name)
       member_node[:drbd] ||= {}
       member_node[:drbd][:local_node_id] = is_founder ? 0 : 1
       member_node[:drbd][:remote_node_id] = is_founder ? 1 : 0
+      member_node[:pacemaker] ||= {}
+      member_node[:pacemaker][:drbd] ||= {}
+      member_node[:pacemaker][:drbd][:nodes] = drbd_nodes
       member_node[:crowbar_wall][:cluster_members_changed] =
         cluster_members_changed && old_members.include?(member_node.name)
       member_node.save


### PR DESCRIPTION
We have to allow user to add a new node into 2-node DRBD cluster, so that such cluster can hold (3-node) galera configuration later.

But as (our version of) DRBD needs exactly 2 nodes, there are some tweaks necessary so that the extra node does not have DRBD configured, although it is part of the pacemaker cluster.