### PR TITLE
haproxy: use secure defaults

### DIFF
--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -11,6 +11,12 @@ global
 	daemon
 	stats socket /var/lib/haproxy/stats.sock user haproxy group haproxy mode 0640 level operator
 
+	tune.ssl.default-dh-param 2048
+	ssl-default-bind-options no-sslv3 no-tlsv10
+	ssl-default-server-options no-sslv3 no-tlsv10
+	ssl-default-bind-ciphers DEFAULT_SUSE
+	ssl-default-server-ciphers DEFAULT_SUSE
+
 defaults
 	log     global
 	mode    tcp


### PR DESCRIPTION
Disable SSLv3 and TLS1.0 and set the DH parameters nicely
so that we don't use weak DH. Also reduce the default ciphers
to the SUSE recommended defaults. None of that is raelly effective
yet in mode tcp though which we use by default.