### PR TITLE
Bump schema revision to 300 after release

### DIFF
--- a/chef/data_bags/crowbar/migrate/pacemaker/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/pacemaker/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-pacemaker.json
+++ b/chef/data_bags/crowbar/template-pacemaker.json
@@ -66,7 +66,7 @@
     "pacemaker": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 203,
+      "schema-revision": 300,
       "element_states": {
         "pacemaker-cluster-member"    : [ "readying", "ready", "applying" ],
         "hawk-server"                 : [ "readying", "ready", "applying" ],


### PR DESCRIPTION
To give some head room for future schema migrations in the
stable/5.0-pike branch we bump the schema revision for all barclamps to
300. The migration itself is a noop it's just there to ensure the
schema-revision is increased on all existing proposals and roles (mainly
needed for future upgrades from stable/5.0-pike).