### PR TITLE
[5.0] pacemaker: Cleanup 4.0 specific attribute

### DIFF
--- a/chef/data_bags/crowbar/migrate/pacemaker/204_remove_allow_larger_cluster.rb
+++ b/chef/data_bags/crowbar/migrate/pacemaker/204_remove_allow_larger_cluster.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  a["drbd"].delete("allow_larger_cluster")
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  if ta["drbd"].key? "allow_larger_cluster"
+    a["drbd"]["allow_larger_cluster"] = ta["drbd"]["allow_larger_cluster"]
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-pacemaker.json
+++ b/chef/data_bags/crowbar/template-pacemaker.json
@@ -66,7 +66,7 @@
     "pacemaker": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 203,
+      "schema-revision": 204,
       "element_states": {
         "pacemaker-cluster-member"    : [ "readying", "ready", "applying" ],
         "hawk-server"                 : [ "readying", "ready", "applying" ],


### PR DESCRIPTION
In the 4.0 branch with schema revision 106 we introduced the
["drbd"]["allow_larger_cluster"] attribute. That attribute is only
needed in 4.0 and was never forward ported to 5.0. So this needs to
be cleaned up during the upgrade from 4.0 to 5.0