### PR TITLE
pacemaker: Wait more for cluster to be online

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -108,10 +108,16 @@ include_recipe "crowbar-pacemaker::pacemaker_authkey"
 # nodes) -- see the corosync::authkey_generator recipe.
 ruby_block "mark node as ready for pacemaker" do
   block do
+    dirty = false
     unless node[:pacemaker][:setup]
       node.set[:pacemaker][:setup] = true
-      node.save
+      dirty = true
     end
+    if node[:crowbar_wall][:cluster_node_added]
+      node.set[:crowbar_wall][:cluster_node_added] = false
+      dirty = true
+    end
+    node.save if dirty
   end
 end
 

--- a/chef/cookbooks/pacemaker/recipes/default.rb
+++ b/chef/cookbooks/pacemaker/recipes/default.rb
@@ -59,11 +59,19 @@ nodes_names = node[:pacemaker][:elements]["pacemaker-cluster-member"].map do |n|
   n.gsub(/\..*/, "")
 end
 
+# When newly added node is faster than the old nodes, it can finish the default timeout
+# here and continue chef-client run before the cluster is fully (re)configured.
+# If it reaches any syncmark it can get: "Could not map name=<nodename> to a UUID" error.
+# Waiting a bit more gives the rest of the cluster some time to recognize the new member.
+# Extending this timeout unconditionally would cause a deadlock with the "Waiting for
+# cluster founder to be set up" loop in crowbar-pacemaker cookbook.
+online_timeout = node.fetch("crowbar_wall", {})[:cluster_node_added] ? 120 : 60
+
 ruby_block "wait for cluster to be online" do
   block do
     require "timeout"
     begin
-      Timeout.timeout(60) do
+      Timeout.timeout(online_timeout) do
         loop do
           # example of 'crm_node -l' output:
           # 1084813649 d52-54-77-77-01-02 member

--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -469,6 +469,8 @@ class PacemakerService < ServiceObject
       member_node[:drbd][:remote_node_id] = is_founder ? 1 : 0
       member_node[:crowbar_wall][:cluster_members_changed] =
         cluster_members_changed && old_members.include?(member_node.name)
+      member_node[:crowbar_wall][:cluster_node_added] =
+        cluster_members_changed && !old_members.include?(member_node.name)
       member_node.save
     end
 


### PR DESCRIPTION
If newly added node is fast and goes ahead of the founder it can hit the first
syncmark before cluster is fully configured. Added flag enables conditional timeout
extension for new nodes while keeping old timeout during initial deployment.

(cherry picked from commit 655ae273723a5500d9336544fe71681a5afcd412)

forward port of #335 