### PR TITLE
haproxy: Increase global maxconn limit to 16384

### DIFF
--- a/chef/cookbooks/haproxy/attributes/default.rb
+++ b/chef/cookbooks/haproxy/attributes/default.rb
@@ -23,7 +23,7 @@ default[:haproxy][:platform][:group] = "haproxy"
 default[:haproxy][:platform][:config_file] = "/etc/haproxy/haproxy.cfg"
 default[:haproxy][:platform][:error_dir] = "/etc/haproxy/errorfiles"
 
-default[:haproxy][:global][:maxconn] = 4096
+default[:haproxy][:global][:maxconn] = 16384
 default[:haproxy][:global][:bufsize] = 16384
 default[:haproxy][:global][:maxrewrite] = 4096
 default[:haproxy][:global][:chksize] = 16384


### PR DESCRIPTION
It looks like this is just limiting the setting tha haproxy chooses
itself based on the amount of memory and features is available (as
can be seen in haproxy -vv ). so we don't have to be picky here.