### PR TITLE
[4.0] Update travis config to solve bundler dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ dist: trusty
 
 rvm: 2.1.9
 
+before_install:
+  - rvm @global do gem install bundler -v '< 2.0.0'
+
 matrix:
   include:
     - gemfile: Gemfile


### PR DESCRIPTION
Bundler has been updated and our travis configuration is no longer
working. There's a proposed fix by limiting bunlder version to be less
than 2.0.0:

https://github.com/travis-ci/travis-ci/issues/5290

Our last working bundler version was 1.17.3

(cherry picked from commit 5e69f86c9b1592e53234d990a42fe77617c85774)