### PR TITLE
crowbar-pacemaker: bump sync mark timeout to 300s

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/libraries/synchronization.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/synchronization.rb
@@ -55,7 +55,7 @@ module CrowbarPacemakerSynchronization
   end
 
   # See "Synchronization helpers" documentation
-  def self.wait_for_mark_from_founder(node, mark, fatal = false, timeout = 60)
+  def self.wait_for_mark_from_founder(node, mark, fatal = false, timeout = 300)
     return unless CrowbarPacemakerHelper.cluster_enabled?(node)
     return if CrowbarPacemakerHelper.is_cluster_founder?(node)
     if CrowbarPacemakerHelper.being_upgraded?(node)
@@ -116,7 +116,7 @@ module CrowbarPacemakerSynchronization
   end
 
   # See "Synchronization helpers" documentation
-  def self.synchronize_on_mark(node, mark, fatal = false, timeout = 60)
+  def self.synchronize_on_mark(node, mark, fatal = false, timeout = 300)
     return unless CrowbarPacemakerHelper.cluster_enabled?(node)
 
     attribute = "#{prefix}#{mark}"

--- a/chef/cookbooks/crowbar-pacemaker/resources/sync_mark.rb
+++ b/chef/cookbooks/crowbar-pacemaker/resources/sync_mark.rb
@@ -54,4 +54,4 @@ attribute :mark,      kind_of: String,  default: nil
 attribute :revision,  kind_of: Integer, default: nil
 
 attribute :fatal,     kind_of: [TrueClass, FalseClass], default: true
-attribute :timeout,   kind_of: Integer, default: 60
+attribute :timeout,   kind_of: Integer, default: 300


### PR DESCRIPTION
We are currently seeing lots of sync mark timeouts in HA
enabled CI jobs. This commit bumps the sync mark timeout
beyond the maximum of how far the timeouts where observed to
be exceeded.

This should fix the timeout problems we are currently seeing with HA enabled mkcloud jobs.