### PR TITLE
[5.0] improve galera HA setup (bsc#1122875)

### DIFF
--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -85,7 +85,7 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
 
     <% end -%>
     <% if content[:stick] && content[:stick][:on] && !content[:stick][:on].empty? -%>
-	stick-table type ip size 1
+	stick-table type ip size 1000
 	stick on <%= content[:stick][:on] %>
 
     <% end -%>
@@ -122,8 +122,9 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
         rise = " rise #{server[:rise] || 5}"
         fall = " fall #{server[:fall] || 2}"
         backup = server[:backup] ? " backup" : ""
+        on_marked_down_shutdown = server[:on_marked_down_shutdown] ? " on-marked-down shutdown-sessions" : ""
       %>
-	server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check<%= ssl %><%= inter %><%= fastinter %><%= downinter %><%= rise %><%= fall %><%= backup %>
+        server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check<%= ssl %><%= inter %><%= fastinter %><%= downinter %><%= rise %><%= fall %><%= backup %><%= on_marked_down_shutdown %>
     <% end -%>
   <% end -%>
 <% end -%>


### PR DESCRIPTION
It turns out that haproxy has a known issue with concurrent connections
when using the sticky-table with size 1
Also, there is an scenario using galera that keeps the connections open
to a backend that's declared down. It happens when the health check
fails but the backend still keeps the port open.
This patch fixes both issues increasing the size table to 1000 and
adding an option to shutdown the connections once a backend is marked
down.

Signed-off-by: aojeagarcia <aojeagarcia@suse.com>
(cherry picked from commit 0afb9d334bf5f195b065666e099265f4e5db7b05)