### PR TITLE
crowbar-pacemaker: bump sync mark timeout (SCRD-8179)

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/libraries/synchronization.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/synchronization.rb
@@ -55,7 +55,7 @@ module CrowbarPacemakerSynchronization
   end
 
   # See "Synchronization helpers" documentation
-  def self.wait_for_mark_from_founder(node, mark, fatal = false, timeout = 60)
+  def self.wait_for_mark_from_founder(node, mark, fatal = false, timeout = 120)
     return unless CrowbarPacemakerHelper.cluster_enabled?(node)
     return if CrowbarPacemakerHelper.is_cluster_founder?(node)
     if CrowbarPacemakerHelper.being_upgraded?(node)
@@ -116,7 +116,7 @@ module CrowbarPacemakerSynchronization
   end
 
   # See "Synchronization helpers" documentation
-  def self.synchronize_on_mark(node, mark, fatal = false, timeout = 60)
+  def self.synchronize_on_mark(node, mark, fatal = false, timeout = 120)
     return unless CrowbarPacemakerHelper.cluster_enabled?(node)
 
     attribute = "#{prefix}#{mark}"

--- a/chef/cookbooks/crowbar-pacemaker/resources/sync_mark.rb
+++ b/chef/cookbooks/crowbar-pacemaker/resources/sync_mark.rb
@@ -54,4 +54,4 @@ attribute :mark,      kind_of: String,  default: nil
 attribute :revision,  kind_of: Integer, default: nil
 
 attribute :fatal,     kind_of: [TrueClass, FalseClass], default: true
-attribute :timeout,   kind_of: Integer, default: 60
+attribute :timeout,   kind_of: Integer, default: 120


### PR DESCRIPTION
We are currently seeing sync mark timeouts in Monasca enabled
HA clouds. The reason for these turns out to be the other
controller being a fairly consistent 70s behind the cluster
founder. This causes the sync marks to time out at a timeout
value of 60s. Further investigation didn't reveal any single
culprit (various things added a couple of seconds here and
there and in the end that just summed up to 70s).

This commit bumps the sync mark timeout to 120s to give us a
reasonable amount of breathing space. For we might be able to
shave off a few seconds here and there to get back below the
60s threshold, but that would be very vulnerable to sporadic
delays and/or additional small delays introduced by running
extra code on the cluster founder.