### PR TITLE
pacemaker: "disabled" stonith mode (SCRD-8462)

### DIFF
--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -536,6 +536,8 @@ class PacemakerService < ServiceObject
 
   def validate_proposal_stonith stonith_attributes, members
     case stonith_attributes["mode"]
+    when "disabled"
+      true # nothing to do
     when "manual"
       # nothing to do
     when "sbd"


### PR DESCRIPTION
Allow "disabled" stonith mode to be configured in crowbar proposals.
This mode needs to be used by the Crowbar ECP CI as a temporary
alternative to SBD, which is not currently reliable.