### PR TITLE
crowbar-ha: skip deleted nodes

### DIFF
--- a/crowbar_framework/app/models/api/pacemaker.rb
+++ b/crowbar_framework/app/models/api/pacemaker.rb
@@ -51,7 +51,7 @@ module Api
         ).map! do |node|
           node[:pacemaker][:founder]
         end.uniq
-        founders = cluster_founders_names.map { |name| NodeObject.find_by_name(name) }
+        founders = cluster_founders_names.map { |name| NodeObject.find_by_name(name) }.compact
         return ret if founders.empty?
 
         service_object = CrowbarService.new(Rails.logger)


### PR DESCRIPTION
There might be node names that can not be looked up anymore,
just skip them rather than adding Nil entries to the list.