### PR TITLE
Make default sync_mark timeout configurable + scalable

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/providers/sync_mark.rb
+++ b/chef/cookbooks/crowbar-pacemaker/providers/sync_mark.rb
@@ -21,6 +21,7 @@ def get_options resource
     {}
   end
   timeout = sync_mark_config.fetch("default_timeout", 60)
+  timeout_multiplier = sync_mark_config.fetch("timeout_multiplier", 1.0)
   action = nil
   mark = nil
 
@@ -44,6 +45,8 @@ def get_options resource
   end
 
   raise "Missing mark attribute" if mark.nil?
+
+  timeout = (timeout * timeout_multiplier).to_i
 
   Chef::Log.info("Using timeout #{timeout} for sync_mark #{mark}")
 

--- a/chef/cookbooks/crowbar-pacemaker/resources/sync_mark.rb
+++ b/chef/cookbooks/crowbar-pacemaker/resources/sync_mark.rb
@@ -54,4 +54,4 @@ attribute :mark,      kind_of: String,  default: nil
 attribute :revision,  kind_of: Integer, default: nil
 
 attribute :fatal,     kind_of: [TrueClass, FalseClass], default: true
-attribute :timeout,   kind_of: Integer, default: 60
+attribute :timeout,   kind_of: Integer


### PR DESCRIPTION
This change introduces a new databag item "sync_mark" in "crowbar-config"
databag. It can contain "default_timeout" value and that will be used if
available. Otherwise previous default of 60s will be used.

This is useful in environments where node performance is not consistent.
Such cases were observed in virtualized deployments running on top of cloud
which hosted various other workloads and sometimes non-founders were much
faster than the founder. This lead to situation where some non-founder can
leave "sync window" (with timeout) before the founder even reaches the
"wait" sync_mark.

Another reason for such "inhomogeneous" performance could be (semi)broken
hardware (e.g. RAID cache batteries).

Increasing the default sync_mark timeout in above cases is a workaround
which will "relax" the timing constrains and could possibly make more
of those deployments successfull.

----------------------------------------------------------------

Configurable default timeout value doesn't help in cases where
timeout is cusomized for given resource. Such cases are better covered
with scaling of all timeouts with a multiplier.
E.g.
base:
some_resource/timeout = 60
customized_resource/timeout = 100

with default_timeout = 120:
some_resource/timeout = 120
customized_resource/timeout = 100

with timeout_multipler = 2:
some_resource/timeout = 120
customized_resource/timeout = 200