### PR TITLE
[4.0] corosync: Hardcode ruby version for package installation (SOC-10010)

### DIFF
--- a/chef/cookbooks/corosync/recipes/service.rb
+++ b/chef/cookbooks/corosync/recipes/service.rb
@@ -60,7 +60,7 @@ end
 # chef-client can only use it immediately if we install it at
 # recipe compile-time, not run-time:
 # from the next run onwards:
-rubygem_ruby_shadow = "ruby#{node["languages"]["ruby"]["version"].to_f}-rubygem-ruby-shadow"
+rubygem_ruby_shadow = "ruby2.1-rubygem-ruby-shadow"
 pkg = package rubygem_ruby_shadow do
   action :nothing
 end


### PR DESCRIPTION
Sometimes there is a race condition and ohai didn't collect the ruby
version. to_f evalutes then the version to 0.0 and zypper fails to
install the rubygem `ruby0.0-rubygem-ruby-shadow' not found in package
names`.

(cherry picked from commit 607349330facbcced279a30360bf5ef8e73f8cc5)