### PR TITLE
Drop g-haproxy location before group deletion (bsc#1156914)

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/haproxy.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/haproxy.rb
@@ -74,6 +74,12 @@ if node[:pacemaker][:haproxy][:clusters].key?(cluster_name) && node[:pacemaker][
   # Compatibility with existing deployment: we need to drop the group to create
   # the clone
   group_name = "g-#{service_name}"
+  # drop location constraint first as it would get reassigned to some child of the group
+  # otherwise. See: https://github.com/ClusterLabs/crmsh/issues/140
+  pacemaker_location openstack_pacemaker_controller_only_location_for group_name do
+    action :delete
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
   pacemaker_group group_name do
     action [:stop, :delete]
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }


### PR DESCRIPTION
When container (group) resource is deleted, it's children are not
and all constraints assigned to the container are re-assigned to one
of the children. In g-haproxy case this leads to incorrect situation
where l-g-haproxy-controller constraint is assigned to
vip-admin-cluster-data.
Removing the constraint before the group should avoid such situations.

(cherry picked from commit 8540c40fbbd1f67593b467b94aa11cd6f43fcfdd)

port of #369 