### PR TITLE
[4.0] add ssl termination on haproxy (bsc#1149535)

### DIFF
--- a/chef/cookbooks/haproxy/providers/loadbalancer.rb
+++ b/chef/cookbooks/haproxy/providers/loadbalancer.rb
@@ -42,8 +42,14 @@ action :create do
   section["address"] = new_resource.address
   section["port"] = new_resource.port
   section["use_ssl"] = new_resource.use_ssl
+  section["terminate_ssl"] = new_resource.terminate_ssl
   if new_resource.use_ssl
-    section["mode"] = "tcp"
+    if new_resource.terminate_ssl
+      section["mode"] = "http"
+      section["pemfile"] = new_resource.pemfile
+    else
+      section["mode"] = "tcp"
+    end
   else
     section["mode"] = new_resource.mode
   end
@@ -55,7 +61,7 @@ action :create do
   section["options"] = new_resource.options || []
   if section["options"].empty? || section["options"].include?("defaults")
     section["options"].delete("defaults")
-    if section["use_ssl"]
+    if section["use_ssl"] && !section["terminate_ssl"]
       section["options"] = [["tcpka", "tcplog"], section["options"]].flatten
     elsif section["mode"] == "http"
       section["options"] = [["tcpka", "httplog", "forwardfor"], section["options"]].flatten

--- a/chef/cookbooks/haproxy/resources/loadbalancer.rb
+++ b/chef/cookbooks/haproxy/resources/loadbalancer.rb
@@ -29,6 +29,8 @@ attribute :mode,    kind_of: String,  default: "http", equal_to: ["http", "tcp",
 attribute :balance, kind_of: String,  default: "",
           equal_to: ["", "roundrobin", "static-rr", "leastconn", "first", "source"]
 attribute :use_ssl, kind_of: [TrueClass, FalseClass], default: false
+attribute :terminate_ssl, kind_of: [TrueClass, FalseClass], default: false
+attribute :pemfile, kind_of: String,  default: ""
 attribute :stick,   kind_of: Hash,    default: {}
 attribute :options, kind_of: Array,   default: []
 attribute :default_server, kind_of: String,  default: ""

--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -39,13 +39,17 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
 
     <% content = node[:haproxy][:sections][type][name] -%>
 <%= type %> <%= name %>
+    <% if content[:terminate_ssl] -%>
+	bind <%= content[:address] %>:<%= content[:port] %> ssl crt <%= content[:pemfile] %>
+    <% else -%>
 	bind <%= content[:address] %>:<%= content[:port] %>
+    <% end -%>
 	mode <%= content[:mode] %>
     <% unless content[:balance].nil? -%>
 	balance <%= content[:balance] %>
     <% end -%>
 
-    <% if content[:use_ssl] # http://www.haproxy.com/blog/maintain-affinity-based-on-ssl-session-id/ -%>
+    <% if content[:use_ssl] && !content[:terminate_ssl]  # http://www.haproxy.com/blog/maintain-affinity-based-on-ssl-session-id/ -%>
 	# maximum SSL session ID length is 32 bytes.
 	stick-table type binary len 32 size 100k expire <%= content[:stick] ? content[:stick][:expire] : "32m" %>
 
@@ -123,8 +127,9 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
         fall = " fall #{server[:fall] || 2}"
         backup = server[:backup] ? " backup" : ""
         on_marked_down_shutdown = server[:on_marked_down_shutdown] ? " on-marked-down shutdown-sessions" : ""
+        terminate_ssl = content[:terminate_ssl] ? " ssl" : ""
       %>
-        server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check<%= ssl %><%= inter %><%= fastinter %><%= downinter %><%= rise %><%= fall %><%= backup %><%= on_marked_down_shutdown %>
+        server <%= server[:name] %> <%= server[:address] %>:<%= server[:port] %> check<%= ssl %><%= inter %><%= fastinter %><%= downinter %><%= rise %><%= fall %><%= backup %><%= on_marked_down_shutdown %><%= terminate_ssl %>
     <% end -%>
   <% end -%>
 <% end -%>


### PR DESCRIPTION
If the requests are passed in tcp mode, the source ip gets replaced with
the one of the node where haproxy lives, and there is no way to get the
original ip on the services side.

Add an ability to terminate ssl on haproxy. Using `terminate_ssl` and
`pemfile` will make haproxy switch to http mode and make plain https
requests to the service.