### PR TITLE
Hide libvirt STONITH option from the UI (bsc#1084739)

### DIFF
--- a/crowbar_framework/app/helpers/barclamp/pacemaker_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/pacemaker_helper.rb
@@ -52,8 +52,7 @@ module Barclamp
           [t(".stonith_modes.ipmi_barclamp"), "ipmi_barclamp"],
           [t(".stonith_modes.sbd"), "sbd"],
           [t(".stonith_modes.shared"), "shared"],
-          [t(".stonith_modes.per_node"), "per_node"],
-          [t(".stonith_modes.libvirt"), "libvirt"]
+          [t(".stonith_modes.per_node"), "per_node"]
         ],
         selected.to_s
       )

--- a/crowbar_framework/app/views/barclamp/pacemaker/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/pacemaker/_edit_attributes.html.haml
@@ -56,7 +56,7 @@
       %legend
         = t(".stonith_header")
 
-      = select_field %w(stonith mode), :collection => :stonith_mode_for_pacemaker, "data-showit" => ["sbd", "shared", "per_node", "libvirt"].join(";"), "data-showit-target" => "#stonith_sbd_container;#stonith_shared_container;#stonith_per_node_container;#stonith_libvirt_container", "data-showit-direct" => "true"
+      = select_field %w(stonith mode), :collection => :stonith_mode_for_pacemaker, "data-showit" => ["sbd", "shared", "per_node"].join(";"), "data-showit-target" => "#stonith_sbd_container;#stonith_shared_container;#stonith_per_node_container", "data-showit-direct" => "true"
 
       #stonith_sbd_container{ "data-nodes" => node_aliases.to_json }
         .alert.alert-info
@@ -91,13 +91,6 @@
               %th.col-sm-9
                 = t ".stonith.per_node.params"
           %tbody
-
-      #stonith_libvirt_container
-        .alert.alert-warning
-          = t('.stonith.libvirt.dev_only')
-        = string_field %w(stonith libvirt hypervisor_ip)
-        %span.help-block
-          = t('.stonith.libvirt.hypervisor_ip_hint')
 
       = select_field %w(corosync require_clean_for_autostart_wrapper), :collection => :require_clean_for_autostart_wrapper_for_pacemaker
       %span.help-block

--- a/crowbar_framework/config/locales/pacemaker/en.yml
+++ b/crowbar_framework/config/locales/pacemaker/en.yml
@@ -91,7 +91,6 @@ en:
           sbd: 'Configured with STONITH Block Devices (SBD)'
           shared: 'Configured with one shared resource for the whole cluster'
           per_node: 'Configured with one resource per node'
-          libvirt: 'Configured for nodes running in libvirt'
         stonith:
           mode: 'Configuration mode for STONITH'
           no_nodes: 'No nodes have been assigned a pacemaker role.'
@@ -109,10 +108,6 @@ en:
             agent: 'Fencing agent'
             name: 'Node name'
             params: 'Parameters for agent'
-          libvirt:
-            dev_only: 'The libvirt STONITH configuration is not supported, it should be used for development or testing purposes only!'
-            hypervisor_ip: 'IP address of hypervisor'
-            hypervisor_ip_hint: 'Note that libvirt on your host needs to be configured to listen on TCP, with no TLS and no authentication. The firewall should also be configured to allow communication from the virtual machines.'
         notifications_header: 'Mail Notifications'
         notifications:
           smtp:


### PR DESCRIPTION
The setup is unrealiable, based on the version of OS/libvirt.
As it is not supported anyway, better hide it from the UI completely.

It is still possible to deploy when not using the GUI.