### PR TITLE
pacemaker: remove node on delete (SOC-11240)

### DIFF
--- a/chef/data_bags/crowbar/migrate/pacemaker/302_add_delete_transition.rb
+++ b/chef/data_bags/crowbar/migrate/pacemaker/302_add_delete_transition.rb
@@ -1,0 +1,11 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  deployment["config"]["transition_list"] = template_deployment["config"]["transition_list"]
+  deployment["config"]["transitions"] = template_deployment["config"]["transitions"]
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  deployment["config"]["transition_list"] = template_deployment["config"]["transition_list"]
+  deployment["config"]["transitions"] = template_deployment["config"]["transitions"]
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-pacemaker.json
+++ b/chef/data_bags/crowbar/template-pacemaker.json
@@ -65,7 +65,7 @@
     "pacemaker": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 301,
+      "schema-revision": 302,
       "element_states": {
         "pacemaker-cluster-member"    : [ "readying", "ready", "applying" ],
         "hawk-server"                 : [ "readying", "ready", "applying" ],
@@ -80,9 +80,8 @@
       "config": {
         "environment": "pacemaker-base-config",
         "mode": "full",
-        "transitions": false,
-        "transition_list": [
-        ]
+        "transitions": true,
+        "transition_list": [ "delete" ]
       }
     }
   }


### PR DESCRIPTION
On node delete, crowbar doesn't execute pacemaker barclamp due to
default pacemaker proposal not having transitions attribute enabled
for delete. This change adds said feature and the delete transition. 